### PR TITLE
Phase 1.1: Add LRU cache to stem() function

### DIFF
--- a/doc_search/stemmer.py
+++ b/doc_search/stemmer.py
@@ -8,6 +8,7 @@ This is a complete implementation with all 5 steps.
 """
 
 import re
+from functools import lru_cache
 
 
 def _is_consonant(word: str, i: int) -> bool:
@@ -298,9 +299,12 @@ def _step5b(word: str) -> str:
     return word
 
 
+@lru_cache(maxsize=10000)
 def stem(word: str) -> str:
     """
     Apply the Porter Stemming algorithm to a word.
+    
+    Results are cached using LRU cache for improved performance on repeated words.
     
     Args:
         word: The word to stem.


### PR DESCRIPTION
Adds LRU caching to the Porter stemmer's stem() function for improved performance on repeated words.

## Changes
- Import `lru_cache` from functools
- Add `@lru_cache(maxsize=10000)` decorator to `stem()` function
- Update docstring to document caching behavior

## Performance Impact
The stemmer is called frequently during indexing and searching. Caching stems of commonly repeated words (articles, common terms) significantly reduces redundant computation.

Closes #6