### PR TITLE
Phase 1.2: Validate BM25 k1/b parameters

### DIFF
--- a/doc_search/indexer.py
+++ b/doc_search/indexer.py
@@ -23,6 +23,12 @@ class BM25Index:
     """
     
     def __init__(self, k1: float = 1.5, b: float = 0.75, stem: bool = True):
+        # Validate BM25 parameters
+        if k1 < 0:
+            raise ValueError(f"k1 must be non-negative, got {k1}")
+        if not (0 <= b <= 1):
+            raise ValueError(f"b must be between 0 and 1, got {b}")
+        
         self.k1 = k1
         self.b = b
         self.stem = stem

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,0 +1,59 @@
+"""Tests for BM25Index class."""
+
+import unittest
+from doc_search.indexer import BM25Index
+
+
+class TestBM25IndexParameters(unittest.TestCase):
+    """Tests for BM25 parameter validation."""
+    
+    def test_default_parameters(self):
+        """Default parameters should work."""
+        index = BM25Index()
+        self.assertEqual(index.k1, 1.5)
+        self.assertEqual(index.b, 0.75)
+        self.assertTrue(index.stem)
+    
+    def test_custom_valid_parameters(self):
+        """Custom valid parameters should work."""
+        index = BM25Index(k1=2.0, b=0.5, stem=False)
+        self.assertEqual(index.k1, 2.0)
+        self.assertEqual(index.b, 0.5)
+        self.assertFalse(index.stem)
+    
+    def test_k1_zero_allowed(self):
+        """k1=0 should be allowed."""
+        index = BM25Index(k1=0)
+        self.assertEqual(index.k1, 0)
+    
+    def test_k1_negative_rejected(self):
+        """Negative k1 should raise ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            BM25Index(k1=-0.5)
+        self.assertIn('k1', str(ctx.exception))
+    
+    def test_b_zero_allowed(self):
+        """b=0 should be allowed (no length normalization)."""
+        index = BM25Index(b=0)
+        self.assertEqual(index.b, 0)
+    
+    def test_b_one_allowed(self):
+        """b=1 should be allowed (full length normalization)."""
+        index = BM25Index(b=1)
+        self.assertEqual(index.b, 1)
+    
+    def test_b_negative_rejected(self):
+        """Negative b should raise ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            BM25Index(b=-0.1)
+        self.assertIn('b', str(ctx.exception))
+    
+    def test_b_greater_than_one_rejected(self):
+        """b > 1 should raise ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            BM25Index(b=1.5)
+        self.assertIn('b', str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds parameter validation to BM25Index constructor.

## Changes
- Validate k1 >= 0 (term frequency saturation must be non-negative)
- Validate 0 <= b <= 1 (length normalization factor must be in [0,1])
- Add test_indexer.py with 8 test cases for parameter validation

## Rationale
Invalid BM25 parameters lead to nonsensical scores. Failing fast at construction time is better than producing garbage results later.

Closes #7