### PR TITLE
Phase 1.4: Add --log-requests flag to serve command

### DIFF
--- a/doc_search/__main__.py
+++ b/doc_search/__main__.py
@@ -517,7 +517,8 @@ def cmd_serve(args):
     stats = engine.get_stats()
     
     # Start server
-    server = run_server(engine, host=args.host, port=args.port, version=__version__)
+    log_requests = getattr(args, 'log_requests', False)
+    server = run_server(engine, host=args.host, port=args.port, version=__version__, log_requests=log_requests)
     
     url = f"http://{args.host}:{args.port}"
     
@@ -703,6 +704,8 @@ Examples:
                              help='Host to bind to (default: 127.0.0.1)')
     serve_parser.add_argument('--open', '-o', action='store_true',
                              help='Open browser automatically')
+    serve_parser.add_argument('--log-requests', action='store_true',
+                             help='Log HTTP requests to stdout')
     serve_parser.add_argument('--separate-paths', action='store_true',
                              help='Use if site was crawled with --separate-paths')
     serve_parser.set_defaults(func=cmd_serve)

--- a/doc_search/server.py
+++ b/doc_search/server.py
@@ -620,10 +620,14 @@ class SearchHandler(BaseHTTPRequestHandler):
     
     engine: SearchEngine = None
     version: str = ""
+    log_requests: bool = False
     
     def log_message(self, format, *args):
-        """Suppress default logging."""
-        pass
+        """Log HTTP requests if enabled."""
+        if self.log_requests:
+            message = format % args
+            timestamp = time.strftime('%Y-%m-%d %H:%M:%S')
+            print(f"[{timestamp}] {self.address_string()} - {message}")
     
     def send_html(self, content: str, status: int = 200):
         """Send HTML response."""
@@ -692,10 +696,23 @@ def run_server(
     engine: SearchEngine,
     host: str = '127.0.0.1',
     port: int = 8888,
-    version: str = ""
+    version: str = "",
+    log_requests: bool = False
 ) -> HTTPServer:
-    """Create and return the HTTP server (doesn't start it)."""
+    """Create and return the HTTP server (doesn't start it).
+    
+    Args:
+        engine: The SearchEngine instance to use for queries
+        host: Host address to bind to
+        port: Port number to listen on
+        version: Version string to display
+        log_requests: If True, log HTTP requests to stdout
+        
+    Returns:
+        HTTPServer instance (call serve_forever() to start)
+    """
     SearchHandler.engine = engine
     SearchHandler.version = version
+    SearchHandler.log_requests = log_requests
     server = HTTPServer((host, port), SearchHandler)
     return server


### PR DESCRIPTION
Enables optional HTTP request logging for the web UI server.

## Usage
```bash
python -m doc_search serve ./site_data --log-requests
```

## Log Format
```
[2024-02-01 14:30:45] 127.0.0.1 - "GET /?q=search+query HTTP/1.1" 200 -
```

## Changes
- `__main__.py`: Add `--log-requests` flag to serve command
- `server.py`: Add `log_requests` class attribute and conditional logging in `log_message()`
- `run_server()`: Accept and propagate `log_requests` parameter

## Use Cases
- Debugging search issues
- Monitoring traffic patterns
- Development/testing

Closes #9