### PR TITLE
Phase 1.6: Add hash_string helper function

### DIFF
--- a/doc_search/utils.py
+++ b/doc_search/utils.py
@@ -201,9 +201,23 @@ def is_same_domain(url1: str, url2: str) -> bool:
     return get_domain(url1) == get_domain(url2)
 
 
+def hash_string(s: str, length: int = 16) -> str:
+    """
+    Generate a truncated SHA256 hash of a string.
+    
+    Args:
+        s: String to hash
+        length: Number of hex characters to return (max 64)
+        
+    Returns:
+        Truncated hex digest string
+    """
+    return hashlib.sha256(s.encode()).hexdigest()[:length]
+
+
 def url_to_filename(url: str) -> str:
     """Convert URL to a safe filename using hash."""
-    return hashlib.sha256(url.encode()).hexdigest()[:16]
+    return hash_string(url, length=16)
 
 
 def site_hash(url: str, include_path: bool = False) -> str:
@@ -225,7 +239,7 @@ def site_hash(url: str, include_path: bool = False) -> str:
     else:
         # Hash domain only (default - one folder per domain)
         key = get_domain(url)
-    return hashlib.sha256(key.encode()).hexdigest()[:12]
+    return hash_string(key, length=12)
 
 
 def resolve_url(base_url: str, href: str) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,10 @@ Tests for utility functions including URL normalization.
 """
 
 import unittest
-from doc_search.utils import normalize_url, tokenize, is_valid_url, get_domain
+from doc_search.utils import (
+    normalize_url, tokenize, is_valid_url, get_domain,
+    hash_string, url_to_filename, site_hash
+)
 
 
 class TestNormalizeUrl(unittest.TestCase):
@@ -192,6 +195,90 @@ class TestIsValidUrl(unittest.TestCase):
     def test_relative_url(self):
         """Should reject relative URLs."""
         self.assertFalse(is_valid_url("/path/to/page"))
+
+
+class TestHashString(unittest.TestCase):
+    """Tests for hash_string function."""
+    
+    def test_default_length(self):
+        """Default length should be 16 characters."""
+        result = hash_string("test")
+        self.assertEqual(len(result), 16)
+    
+    def test_custom_length(self):
+        """Should respect custom length parameter."""
+        result = hash_string("test", length=8)
+        self.assertEqual(len(result), 8)
+        
+        result = hash_string("test", length=32)
+        self.assertEqual(len(result), 32)
+    
+    def test_deterministic(self):
+        """Same input should produce same output."""
+        result1 = hash_string("hello world")
+        result2 = hash_string("hello world")
+        self.assertEqual(result1, result2)
+    
+    def test_different_inputs(self):
+        """Different inputs should produce different outputs."""
+        result1 = hash_string("test1")
+        result2 = hash_string("test2")
+        self.assertNotEqual(result1, result2)
+    
+    def test_hex_characters(self):
+        """Output should be valid hex characters."""
+        import re
+        result = hash_string("test")
+        self.assertTrue(re.match(r'^[0-9a-f]+$', result))
+
+
+class TestUrlToFilename(unittest.TestCase):
+    """Tests for url_to_filename function."""
+    
+    def test_returns_hash(self):
+        """Should return a hash string."""
+        result = url_to_filename("https://example.com/page")
+        self.assertEqual(len(result), 16)
+    
+    def test_deterministic(self):
+        """Same URL should produce same filename."""
+        url = "https://example.com/test"
+        result1 = url_to_filename(url)
+        result2 = url_to_filename(url)
+        self.assertEqual(result1, result2)
+    
+    def test_different_urls(self):
+        """Different URLs should produce different filenames."""
+        result1 = url_to_filename("https://example.com/page1")
+        result2 = url_to_filename("https://example.com/page2")
+        self.assertNotEqual(result1, result2)
+
+
+class TestSiteHash(unittest.TestCase):
+    """Tests for site_hash function."""
+    
+    def test_default_length(self):
+        """Should return 12-character hash by default."""
+        result = site_hash("https://example.com/docs")
+        self.assertEqual(len(result), 12)
+    
+    def test_domain_only_default(self):
+        """By default, should hash only the domain."""
+        result1 = site_hash("https://example.com/path1")
+        result2 = site_hash("https://example.com/path2")
+        self.assertEqual(result1, result2)
+    
+    def test_include_path(self):
+        """With include_path=True, should include path in hash."""
+        result1 = site_hash("https://example.com/path1", include_path=True)
+        result2 = site_hash("https://example.com/path2", include_path=True)
+        self.assertNotEqual(result1, result2)
+    
+    def test_trailing_slash_normalized(self):
+        """Trailing slash should not affect hash when include_path=True."""
+        result1 = site_hash("https://example.com/docs/", include_path=True)
+        result2 = site_hash("https://example.com/docs", include_path=True)
+        self.assertEqual(result1, result2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Creates a common hash_string helper function to consolidate duplicate hashing logic.

## New Function

### `hash_string(s: str, length: int = 16) -> str`
Generate a truncated SHA256 hash of a string.

## Refactored Functions

### `url_to_filename(url: str) -> str`
Now uses `hash_string(url, length=16)` internally.

### `site_hash(url: str, include_path: bool = False) -> str`
Now uses `hash_string(key, length=12)` internally.

## Benefits
- Single source of truth for hashing logic
- Configurable output length via the helper
- Easier to modify hashing behavior in one place
- Enables other code to use consistent hashing

## Tests
Added 12 new tests:
- TestHashString: 5 tests (length, determinism, uniqueness, hex output)
- TestUrlToFilename: 3 tests (length, determinism, uniqueness)
- TestSiteHash: 4 tests (length, domain-only default, include_path behavior)

Closes #11