### PR TITLE
Phase 1.7: Add --per-page and --max-results flags to serve command

### DIFF
--- a/doc_search/__main__.py
+++ b/doc_search/__main__.py
@@ -518,7 +518,10 @@ def cmd_serve(args):
     
     # Start server
     log_requests = getattr(args, 'log_requests', False)
-    server = run_server(engine, host=args.host, port=args.port, version=__version__, log_requests=log_requests)
+    per_page = getattr(args, 'per_page', 10)
+    max_results = getattr(args, 'max_results', 100)
+    server = run_server(engine, host=args.host, port=args.port, version=__version__, 
+                       log_requests=log_requests, per_page=per_page, max_results=max_results)
     
     url = f"http://{args.host}:{args.port}"
     
@@ -706,6 +709,10 @@ Examples:
                              help='Open browser automatically')
     serve_parser.add_argument('--log-requests', action='store_true',
                              help='Log HTTP requests to stdout')
+    serve_parser.add_argument('--per-page', type=int, default=10,
+                             help='Results per page (default: 10)')
+    serve_parser.add_argument('--max-results', type=int, default=100,
+                             help='Maximum total results for pagination (default: 100)')
     serve_parser.add_argument('--separate-paths', action='store_true',
                              help='Use if site was crawled with --separate-paths')
     serve_parser.set_defaults(func=cmd_serve)

--- a/doc_search/server.py
+++ b/doc_search/server.py
@@ -621,6 +621,8 @@ class SearchHandler(BaseHTTPRequestHandler):
     engine: SearchEngine = None
     version: str = ""
     log_requests: bool = False
+    per_page: int = 10
+    max_results: int = 100
     
     def log_message(self, format, *args):
         """Log HTTP requests if enabled."""
@@ -652,8 +654,8 @@ class SearchHandler(BaseHTTPRequestHandler):
         except ValueError:
             page = 1
         
-        per_page = 10
-        max_results = 100  # Maximum results to fetch
+        per_page = self.per_page
+        max_results = self.max_results
         
         # Get stats
         stats = self.engine.get_stats() if self.engine else {}
@@ -697,7 +699,9 @@ def run_server(
     host: str = '127.0.0.1',
     port: int = 8888,
     version: str = "",
-    log_requests: bool = False
+    log_requests: bool = False,
+    per_page: int = 10,
+    max_results: int = 100
 ) -> HTTPServer:
     """Create and return the HTTP server (doesn't start it).
     
@@ -707,6 +711,8 @@ def run_server(
         port: Port number to listen on
         version: Version string to display
         log_requests: If True, log HTTP requests to stdout
+        per_page: Number of results per page (default: 10)
+        max_results: Maximum total results for pagination (default: 100)
         
     Returns:
         HTTPServer instance (call serve_forever() to start)
@@ -714,5 +720,7 @@ def run_server(
     SearchHandler.engine = engine
     SearchHandler.version = version
     SearchHandler.log_requests = log_requests
+    SearchHandler.per_page = per_page
+    SearchHandler.max_results = max_results
     server = HTTPServer((host, port), SearchHandler)
     return server


### PR DESCRIPTION
## Description
Add configurable pagination settings for the web UI.

## Changes
- Add `--per-page` flag (default: 10) - results per page
- Add `--max-results` flag (default: 100) - max total results
- Pass values through `cmd_serve()` to `run_server()`
- Update `SearchHandler` to use configurable values

## Usage
```bash
python -m doc_search serve site --per-page 20 --max-results 50
```

## Testing
All 204 tests pass.

Closes #12