### PR TITLE
Phase 3.3: Extract RateLimiter class to rate_limiter.py

### DIFF
--- a/doc_search/crawler.py
+++ b/doc_search/crawler.py
@@ -10,7 +10,6 @@ import ssl
 import gzip
 import hashlib
 import threading
-from collections import defaultdict
 from pathlib import Path
 from typing import Optional, Set, Dict, Any, Callable, Tuple, List
 from urllib.request import Request, urlopen
@@ -29,6 +28,7 @@ from .constants import (
     CHECKPOINT_INTERVAL as CHECKPOINT_INTERVAL_CONST, DEFAULT_RATE_LIMIT_BACKOFF
 )
 from .crawl_state import CrawlState
+from .rate_limiter import RateLimiter
 
 
 # Extensions that should never be crawled (archives, media, binaries)
@@ -71,61 +71,6 @@ SKIP_PATH_PATTERNS = [
     '/packages/', '/pkg/',
     '/binaries/', '/bin/',
 ]
-
-
-class RateLimiter:
-    """
-    Thread-safe per-domain rate limiter.
-    """
-    
-    def __init__(self, default_delay: float = DEFAULT_CRAWL_DELAY):
-        self.default_delay = default_delay
-        self._domain_delays: Dict[str, float] = {}
-        self._last_request: Dict[str, float] = defaultdict(float)
-        self._backoff_until: Dict[str, float] = defaultdict(float)
-        self._lock = threading.Lock()
-    
-    def set_domain_delay(self, domain: str, delay: float):
-        """Set custom delay for a specific domain."""
-        with self._lock:
-            self._domain_delays[domain] = delay
-    
-    def get_delay(self, domain: str) -> float:
-        """Get delay for a domain."""
-        with self._lock:
-            return self._domain_delays.get(domain, self.default_delay)
-    
-    def set_backoff(self, domain: str, seconds: float):
-        """Set backoff until time for a domain."""
-        with self._lock:
-            self._backoff_until[domain] = time.time() + seconds
-    
-    def wait_for_domain(self, domain: str):
-        """Wait according to rate limiting rules for a domain."""
-        with self._lock:
-            now = time.time()
-            
-            # Check backoff
-            backoff_until = self._backoff_until.get(domain, 0)
-            if now < backoff_until:
-                wait_time = backoff_until - now
-                self._lock.release()
-                time.sleep(wait_time)
-                self._lock.acquire()
-                now = time.time()
-            
-            # Normal delay between requests
-            delay = self._domain_delays.get(domain, self.default_delay)
-            last = self._last_request.get(domain, 0)
-            elapsed = now - last
-            
-            if elapsed < delay:
-                wait_time = delay - elapsed
-                self._lock.release()
-                time.sleep(wait_time)
-                self._lock.acquire()
-            
-            self._last_request[domain] = time.time()
 
 
 class Crawler:

--- a/doc_search/rate_limiter.py
+++ b/doc_search/rate_limiter.py
@@ -1,0 +1,77 @@
+"""
+Thread-safe per-domain rate limiter for web crawling.
+
+This module provides the RateLimiter class for enforcing polite
+crawling behavior with configurable per-domain delays and backoff support.
+"""
+
+import time
+import threading
+from collections import defaultdict
+from typing import Dict
+
+from .constants import DEFAULT_CRAWL_DELAY
+
+
+class RateLimiter:
+    """
+    Thread-safe per-domain rate limiter.
+    
+    Enforces minimum delays between requests to the same domain,
+    supports custom per-domain delays, and handles backoff for rate limiting.
+    """
+    
+    def __init__(self, default_delay: float = DEFAULT_CRAWL_DELAY):
+        """
+        Initialize rate limiter.
+        
+        Args:
+            default_delay: Default delay in seconds between requests to the same domain
+        """
+        self.default_delay = default_delay
+        self._domain_delays: Dict[str, float] = {}
+        self._last_request: Dict[str, float] = defaultdict(float)
+        self._backoff_until: Dict[str, float] = defaultdict(float)
+        self._lock = threading.Lock()
+    
+    def set_domain_delay(self, domain: str, delay: float):
+        """Set custom delay for a specific domain."""
+        with self._lock:
+            self._domain_delays[domain] = delay
+    
+    def get_delay(self, domain: str) -> float:
+        """Get delay for a domain."""
+        with self._lock:
+            return self._domain_delays.get(domain, self.default_delay)
+    
+    def set_backoff(self, domain: str, seconds: float):
+        """Set backoff until time for a domain."""
+        with self._lock:
+            self._backoff_until[domain] = time.time() + seconds
+    
+    def wait_for_domain(self, domain: str):
+        """Wait according to rate limiting rules for a domain."""
+        with self._lock:
+            now = time.time()
+            
+            # Check backoff
+            backoff_until = self._backoff_until.get(domain, 0)
+            if now < backoff_until:
+                wait_time = backoff_until - now
+                self._lock.release()
+                time.sleep(wait_time)
+                self._lock.acquire()
+                now = time.time()
+            
+            # Normal delay between requests
+            delay = self._domain_delays.get(domain, self.default_delay)
+            last = self._last_request.get(domain, 0)
+            elapsed = now - last
+            
+            if elapsed < delay:
+                wait_time = delay - elapsed
+                self._lock.release()
+                time.sleep(wait_time)
+                self._lock.acquire()
+            
+            self._last_request[domain] = time.time()


### PR DESCRIPTION
## Summary
Extract the RateLimiter class from `crawler.py` to its own module for better organization and testability.

## Changes
- Create `doc_search/rate_limiter.py` module with RateLimiter class
- RateLimiter provides thread-safe per-domain rate limiting:
  - Configurable default delay between requests
  - Custom per-domain delays
  - Backoff support for rate limiting responses

- Update `crawler.py` to import RateLimiter from `rate_limiter`
- Remove duplicate class definition from `crawler.py`
- Remove unused import (defaultdict no longer needed in crawler.py)

## Testing
All 427 tests pass.

## Part of
Phase 3: Module Extraction (Issue 3.3)