### PR TITLE
Phase 4.2: Record errors during crawl

### DIFF
--- a/doc_search/crawler.py
+++ b/doc_search/crawler.py
@@ -282,19 +282,69 @@ class Crawler:
                     wait_time = DEFAULT_RATE_LIMIT_BACKOFF
                 self.rate_limiter.set_backoff(domain, wait_time)
                 self._log(f"  Rate limited, backing off for {wait_time}s")
+                return None, None, {
+                    'error_type': 'http',
+                    'error_message': f'HTTP {e.code}: Rate limited (retry after {wait_time}s)'
+                }
             elif e.code >= 500:
                 self._log(f"  Server error: {e.code}")
+                return None, None, {
+                    'error_type': 'http',
+                    'error_message': f'HTTP {e.code}: Server error'
+                }
             else:
                 self._log(f"  HTTP error: {e.code}")
-            return None, None, {}
+                return None, None, {
+                    'error_type': 'http',
+                    'error_message': f'HTTP {e.code}'
+                }
             
         except URLError as e:
-            self._log(f"  URL error: {e.reason}")
-            return None, None, {}
+            reason = str(e.reason)
+            # Check for SSL errors
+            if 'ssl' in reason.lower() or 'certificate' in reason.lower():
+                self._log(f"  SSL error: {reason}")
+                return None, None, {
+                    'error_type': 'ssl',
+                    'error_message': reason
+                }
+            # Check for timeout
+            elif 'timed out' in reason.lower() or 'timeout' in reason.lower():
+                self._log(f"  Timeout: {reason}")
+                return None, None, {
+                    'error_type': 'timeout',
+                    'error_message': reason
+                }
+            else:
+                self._log(f"  URL error: {reason}")
+                return None, None, {
+                    'error_type': 'network',
+                    'error_message': reason
+                }
+            
+        except ssl.SSLError as e:
+            message = str(e)
+            self._log(f"  SSL error: {message}")
+            return None, None, {
+                'error_type': 'ssl',
+                'error_message': message
+            }
+            
+        except TimeoutError as e:
+            message = str(e) or 'Connection timed out'
+            self._log(f"  Timeout: {message}")
+            return None, None, {
+                'error_type': 'timeout',
+                'error_message': message
+            }
             
         except Exception as e:
-            self._log(f"  Error: {e}")
-            return None, None, {}
+            message = str(e)
+            self._log(f"  Error: {message}")
+            return None, None, {
+                'error_type': 'unknown',
+                'error_message': message
+            }
     
     def _is_skippable_extension(self, url: str) -> bool:
         """Check if URL has an extension that should be skipped."""
@@ -442,6 +492,12 @@ class Crawler:
             return []
         
         if content is None:
+            # Record error if available in metadata
+            error_type = fetch_meta.get('error_type')
+            error_message = fetch_meta.get('error_message')
+            if error_type and error_message:
+                self.state.record_error(url, error_type, error_message)
+            
             # Track failure for retry
             self.state.mark_failed(url, depth)
             return None
@@ -508,6 +564,7 @@ class Crawler:
             
             if result['error']:
                 self._log(f"  Document extraction failed: {result['error']}")
+                self.state.record_error(url, 'parse', f"PDF extraction failed: {result['error']}")
                 self.state.mark_failed(url, depth)
                 return None
             

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1646,6 +1646,210 @@ class TestIncrementalCrawl(CrawlerTestCase):
 
 
 # ============================================================================
+# Crawl Error Recording Tests
+# ============================================================================
+
+class TestCrawlErrorRecording(CrawlerTestCase):
+    """Tests for error recording during crawling."""
+    
+    @patch('doc_search.crawler.urlopen')
+    def test_fetch_returns_http_error_metadata_for_404(self, mock_urlopen):
+        """_fetch should return error metadata for HTTP 404."""
+        crawler = self.create_crawler()
+        
+        mock_urlopen.side_effect = HTTPError(
+            'https://example.com/notfound', 404, 'Not Found', {}, None
+        )
+        
+        content, content_type, metadata = crawler._fetch('https://example.com/notfound')
+        
+        self.assertIsNone(content)
+        self.assertEqual(metadata.get('error_type'), 'http')
+        self.assertIn('404', metadata.get('error_message', ''))
+    
+    @patch('doc_search.crawler.urlopen')
+    def test_fetch_returns_http_error_metadata_for_500(self, mock_urlopen):
+        """_fetch should return error metadata for HTTP 500."""
+        crawler = self.create_crawler()
+        
+        mock_urlopen.side_effect = HTTPError(
+            'https://example.com/error', 500, 'Internal Server Error', {}, None
+        )
+        
+        content, content_type, metadata = crawler._fetch('https://example.com/error')
+        
+        self.assertIsNone(content)
+        self.assertEqual(metadata.get('error_type'), 'http')
+        self.assertIn('500', metadata.get('error_message', ''))
+        self.assertIn('Server error', metadata.get('error_message', ''))
+    
+    @patch('doc_search.crawler.urlopen')
+    def test_fetch_returns_http_error_metadata_for_429(self, mock_urlopen):
+        """_fetch should return error metadata for HTTP 429 (rate limited)."""
+        crawler = self.create_crawler()
+        
+        error = HTTPError(
+            'https://example.com/ratelimited', 429, 'Too Many Requests', {}, None
+        )
+        error.headers = MagicMock()
+        error.headers.get = lambda key, default: '60' if key == 'Retry-After' else default
+        mock_urlopen.side_effect = error
+        
+        content, content_type, metadata = crawler._fetch('https://example.com/ratelimited')
+        
+        self.assertIsNone(content)
+        self.assertEqual(metadata.get('error_type'), 'http')
+        self.assertIn('429', metadata.get('error_message', ''))
+        self.assertIn('Rate limited', metadata.get('error_message', ''))
+    
+    @patch('doc_search.crawler.urlopen')
+    def test_fetch_returns_timeout_error_metadata(self, mock_urlopen):
+        """_fetch should return timeout error metadata."""
+        crawler = self.create_crawler()
+        
+        mock_urlopen.side_effect = URLError('timed out')
+        
+        content, content_type, metadata = crawler._fetch('https://example.com/slow')
+        
+        self.assertIsNone(content)
+        self.assertEqual(metadata.get('error_type'), 'timeout')
+    
+    @patch('doc_search.crawler.urlopen')
+    def test_fetch_returns_ssl_error_metadata(self, mock_urlopen):
+        """_fetch should return SSL error metadata."""
+        crawler = self.create_crawler()
+        
+        mock_urlopen.side_effect = URLError('SSL: CERTIFICATE_VERIFY_FAILED')
+        
+        content, content_type, metadata = crawler._fetch('https://example.com/badcert')
+        
+        self.assertIsNone(content)
+        self.assertEqual(metadata.get('error_type'), 'ssl')
+    
+    @patch('doc_search.crawler.urlopen')
+    def test_fetch_returns_network_error_metadata(self, mock_urlopen):
+        """_fetch should return network error metadata for connection errors."""
+        crawler = self.create_crawler()
+        
+        mock_urlopen.side_effect = URLError('Connection refused')
+        
+        content, content_type, metadata = crawler._fetch('https://example.com/down')
+        
+        self.assertIsNone(content)
+        self.assertEqual(metadata.get('error_type'), 'network')
+        self.assertIn('Connection refused', metadata.get('error_message', ''))
+    
+    @patch('doc_search.crawler.urlopen')
+    def test_process_page_records_http_error(self, mock_urlopen):
+        """_process_page should record HTTP errors in crawl state."""
+        crawler = self.create_crawler()
+        crawler.robots.can_fetch = Mock(return_value=True)
+        
+        mock_urlopen.side_effect = HTTPError(
+            'https://example.com/notfound', 404, 'Not Found', {}, None
+        )
+        
+        # Process page should record the error
+        result = crawler._process_page('https://example.com/notfound', depth=0)
+        
+        self.assertIsNone(result)
+        
+        # Check error was recorded
+        errors = crawler.state.get_errors()
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].url, 'https://example.com/notfound')
+        self.assertEqual(errors[0].error_type, 'http')
+        self.assertIn('404', errors[0].message)
+    
+    @patch('doc_search.crawler.urlopen')
+    def test_process_page_records_timeout_error(self, mock_urlopen):
+        """_process_page should record timeout errors in crawl state."""
+        crawler = self.create_crawler()
+        crawler.robots.can_fetch = Mock(return_value=True)
+        
+        mock_urlopen.side_effect = URLError('Connection timed out')
+        
+        result = crawler._process_page('https://example.com/slow', depth=0)
+        
+        self.assertIsNone(result)
+        
+        errors = crawler.state.get_errors()
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].error_type, 'timeout')
+    
+    @patch('doc_search.crawler.urlopen')
+    def test_process_page_records_ssl_error(self, mock_urlopen):
+        """_process_page should record SSL errors in crawl state."""
+        crawler = self.create_crawler()
+        crawler.robots.can_fetch = Mock(return_value=True)
+        
+        mock_urlopen.side_effect = URLError('SSL certificate verification failed')
+        
+        result = crawler._process_page('https://example.com/badcert', depth=0)
+        
+        self.assertIsNone(result)
+        
+        errors = crawler.state.get_errors()
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].error_type, 'ssl')
+    
+    @patch('doc_search.crawler.urlopen')
+    def test_multiple_errors_recorded(self, mock_urlopen):
+        """Should record multiple errors for multiple failed pages."""
+        crawler = self.create_crawler()
+        crawler.robots.can_fetch = Mock(return_value=True)
+        
+        # First page - 404
+        mock_urlopen.side_effect = HTTPError(
+            'https://example.com/page1', 404, 'Not Found', {}, None
+        )
+        crawler._process_page('https://example.com/page1', depth=0)
+        
+        # Second page - 500
+        mock_urlopen.side_effect = HTTPError(
+            'https://example.com/page2', 500, 'Server Error', {}, None
+        )
+        crawler._process_page('https://example.com/page2', depth=0)
+        
+        # Third page - timeout
+        mock_urlopen.side_effect = URLError('Connection timed out')
+        crawler._process_page('https://example.com/page3', depth=0)
+        
+        errors = crawler.state.get_errors()
+        self.assertEqual(len(errors), 3)
+        
+        # Check error summary
+        summary = crawler.state.get_error_summary()
+        self.assertEqual(summary['http'], 2)
+        self.assertEqual(summary['timeout'], 1)
+    
+    @patch('doc_search.crawler.urlopen')
+    def test_errors_persist_through_checkpoint(self, mock_urlopen):
+        """Errors should be saved and restored through checkpoints."""
+        crawler = self.create_crawler()
+        crawler.robots.can_fetch = Mock(return_value=True)
+        
+        mock_urlopen.side_effect = HTTPError(
+            'https://example.com/error', 404, 'Not Found', {}, None
+        )
+        
+        crawler._process_page('https://example.com/error', depth=0)
+        
+        # Save state
+        crawler.state.save()
+        
+        # Create new crawler instance and load state
+        crawler2 = self.create_crawler()
+        crawler2.state.load()
+        
+        # Errors should be restored
+        errors = crawler2.state.get_errors()
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].url, 'https://example.com/error')
+        self.assertEqual(errors[0].error_type, 'http')
+
+
+# ============================================================================
 # Placeholder for Additional Tests
 # ============================================================================
 


### PR DESCRIPTION
## Summary
Update the crawler to record structured errors using the CrawlError system from Phase 4.1.

## Changes
- Update `_fetch()` to return error metadata in the response tuple
- Categorize errors by type: http, timeout, ssl, network, parse, unknown
- Update `_process_page()` to record errors via `state.record_error()`
- Update `_process_document()` to record PDF extraction errors as parse errors
- Add dedicated exception handling for `ssl.SSLError` and `TimeoutError`

## Error Types
| Type | Description |
|------|-------------|
| `http` | HTTP errors (4xx, 5xx, 429 rate limits) |
| `timeout` | Connection/request timeouts |
| `ssl` | SSL/TLS certificate verification errors |
| `network` | Connection refused, DNS failures |
| `parse` | Document extraction failures (PDF, etc.) |
| `unknown` | Unexpected/unhandled errors |

## Testing
- 449 tests passing (11 new tests)
- Tests verify:
  - Error metadata returned from _fetch for each error type
  - Errors recorded in crawl state from _process_page
  - Multiple errors tracked correctly
  - Error summary by type works
  - Errors persist through save/load

Part of Phase 4 (Error Handling & Observability) from REFACTOR_PLAN.md