### PR TITLE
Phase 4.3: Add error summary to stats command

### DIFF
--- a/doc_search/cli/commands.py
+++ b/doc_search/cli/commands.py
@@ -395,6 +395,9 @@ def cmd_interactive(args):
 
 def cmd_stats(args):
     """Show statistics for a crawled site."""
+    from ..crawl_state import CrawlState
+    from datetime import datetime
+    
     separate_paths = getattr(args, 'separate_paths', False)
     site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
     
@@ -444,6 +447,39 @@ def cmd_stats(args):
         print(f"  Avg document length: {idx_stats['avg_document_length']} terms")
         print(f"  BM25 k1={idx_stats['k1']}, b={idx_stats['b']}")
         print(f"  Index size: {format_size(index_path.stat().st_size)}")
+    
+    # Load and display error summary from crawl state
+    crawl_state_file = site_dir / 'crawl_state.json'
+    if crawl_state_file.exists():
+        state = CrawlState(crawl_state_file)
+        if state.load():
+            errors = state.get_errors()
+            if errors:
+                print()
+                print("Crawl Errors:")
+                
+                # Group errors by type
+                error_summary = state.get_error_summary()
+                for error_type, count in sorted(error_summary.items(), key=lambda x: -x[1]):
+                    print(f"  {error_type}: {count}")
+                
+                print(f"  Total: {len(errors)}")
+                
+                # Show detailed error list if --show-errors flag is set
+                show_errors = getattr(args, 'show_errors', False)
+                if show_errors:
+                    print()
+                    print("Recent Errors (last 10):")
+                    # Sort by timestamp descending and take last 10
+                    recent_errors = sorted(errors, key=lambda e: e.timestamp, reverse=True)[:10]
+                    for error in recent_errors:
+                        timestamp = datetime.fromtimestamp(error.timestamp).strftime('%Y-%m-%d %H:%M:%S')
+                        # Truncate long URLs
+                        url = error.url
+                        if len(url) > 60:
+                            url = url[:57] + '...'
+                        print(f"  [{timestamp}] [{error.error_type}] {url}")
+                        print(f"    {error.message}")
     
     return 0
 

--- a/doc_search/cli/parsers.py
+++ b/doc_search/cli/parsers.py
@@ -175,6 +175,8 @@ def _add_stats_parser(subparsers):
     """Add the stats command parser."""
     stats_parser = subparsers.add_parser('stats', help='Show site statistics')
     stats_parser.add_argument('site_dir', help='Site data directory or original URL')
+    stats_parser.add_argument('--show-errors', '-e', action='store_true',
+                             help='Show detailed list of crawl errors')
     stats_parser.add_argument('--separate-paths', action='store_true',
                              help='Use if site was crawled with --separate-paths')
     stats_parser.set_defaults(func=cmd_stats)


### PR DESCRIPTION
## Summary
Add error summary display to the stats command so users can diagnose crawl issues.

## Changes
- Update `cmd_stats` to load crawl errors from `crawl_state.json`
- Display error counts grouped by type (http, timeout, ssl, network, parse, unknown)
- Add `--show-errors` / `-e` flag to show detailed error list

## Usage
```bash
# Basic stats with error summary
doc_search stats <site_dir>

# With detailed error list (last 10 errors)
doc_search stats <site_dir> --show-errors
```

## Example Output
```
Crawl Errors:
  http: 15
  timeout: 3
  ssl: 1
  Total: 19

Recent Errors (last 10):
  [2026-02-02 10:30:45] [http] https://example.com/page1
    HTTP 404
  [2026-02-02 10:29:30] [timeout] https://example.com/slow...
    Connection timed out
```

## Testing
- 449 tests passing
- Verified CLI help shows new flag
- No existing functionality changed

Part of Phase 4 (Error Handling & Observability) from REFACTOR_PLAN.md