### PR TITLE
Phase 4.4: Add /health endpoint to web server

### DIFF
--- a/doc_search/server.py
+++ b/doc_search/server.py
@@ -623,6 +623,7 @@ class SearchHandler(BaseHTTPRequestHandler):
     log_requests: bool = False
     per_page: int = 10
     max_results: int = 100
+    start_time: float = None  # Server start time for uptime calculation
     
     def log_message(self, format, *args):
         """Log HTTP requests if enabled."""
@@ -640,9 +641,25 @@ class SearchHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
     
+    def send_json(self, data: dict, status: int = 200):
+        """Send JSON response."""
+        import json
+        body = json.dumps(data).encode('utf-8')
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json; charset=utf-8')
+        self.send_header('Content-Length', len(body))
+        self.end_headers()
+        self.wfile.write(body)
+    
     def do_GET(self):
         """Handle GET requests."""
         parsed = urllib.parse.urlparse(self.path)
+        
+        # Handle /health endpoint
+        if parsed.path == '/health':
+            self.handle_health()
+            return
+        
         query_params = urllib.parse.parse_qs(parsed.query)
         
         # Get search query
@@ -662,9 +679,9 @@ class SearchHandler(BaseHTTPRequestHandler):
         
         if query:
             # Perform search - fetch enough for pagination
-            start_time = time.perf_counter()
+            search_start = time.perf_counter()
             all_results = self.engine.search(query, top_k=max_results)
-            elapsed_ms = (time.perf_counter() - start_time) * 1000
+            elapsed_ms = (time.perf_counter() - search_start) * 1000
             
             total_results = len(all_results)
             
@@ -692,6 +709,44 @@ class SearchHandler(BaseHTTPRequestHandler):
             html_content = render_page(stats=stats)
         
         self.send_html(html_content)
+    
+    def handle_health(self):
+        """Handle /health endpoint for monitoring and load balancers."""
+        try:
+            # Get index stats
+            stats = self.engine.get_stats() if self.engine else {}
+            
+            # Calculate uptime
+            uptime_seconds = 0
+            if self.start_time:
+                uptime_seconds = time.time() - self.start_time
+            
+            # Build health response
+            health_data = {
+                'status': 'ok',
+                'documents': stats.get('total_documents', 0),
+                'terms': stats.get('unique_terms', 0),
+                'uptime_seconds': round(uptime_seconds, 1),
+                'version': self.version or __version__
+            }
+            
+            # Determine if healthy (has at least some documents indexed)
+            is_healthy = stats.get('total_documents', 0) > 0
+            status_code = 200 if is_healthy else 503
+            
+            if not is_healthy:
+                health_data['status'] = 'unhealthy'
+                health_data['reason'] = 'No documents indexed'
+            
+            self.send_json(health_data, status_code)
+            
+        except Exception as e:
+            # On error, return 503
+            error_data = {
+                'status': 'unhealthy',
+                'error': str(e)
+            }
+            self.send_json(error_data, 503)
 
 
 def run_server(
@@ -722,5 +777,6 @@ def run_server(
     SearchHandler.log_requests = log_requests
     SearchHandler.per_page = per_page
     SearchHandler.max_results = max_results
+    SearchHandler.start_time = time.time()  # Record server start time
     server = HTTPServer((host, port), SearchHandler)
     return server

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -653,5 +653,112 @@ class TestServerResultRendering(ServerTestCase):
         self.assertIn('>highlight<', body)
 
 
+# ============================================================================
+# Phase 4.4: Health Check Endpoint Tests
+# ============================================================================
+
+class TestHealthEndpoint(ServerTestCase):
+    """Tests for /health endpoint."""
+    
+    @classmethod
+    def setUpClass(cls):
+        """Start test server with mock engine."""
+        cls.engine = MockSearchEngine(stats={
+            'total_documents': 500,
+            'unique_terms': 10000,
+        })
+        cls.start_server(engine=cls.engine)
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Stop test server."""
+        cls.stop_server()
+    
+    def test_health_returns_200_when_healthy(self):
+        """GET /health should return 200 when documents are indexed."""
+        status, headers, body = self.make_request('/health')
+        self.assertEqual(status, 200)
+    
+    def test_health_returns_json(self):
+        """GET /health should return JSON content type."""
+        status, headers, body = self.make_request('/health')
+        content_type = headers.get('Content-Type', '')
+        self.assertIn('application/json', content_type)
+    
+    def test_health_contains_status_ok(self):
+        """Health response should contain status: ok."""
+        import json
+        status, headers, body = self.make_request('/health')
+        data = json.loads(body)
+        self.assertEqual(data['status'], 'ok')
+    
+    def test_health_contains_document_count(self):
+        """Health response should contain document count."""
+        import json
+        status, headers, body = self.make_request('/health')
+        data = json.loads(body)
+        self.assertEqual(data['documents'], 500)
+    
+    def test_health_contains_term_count(self):
+        """Health response should contain term count."""
+        import json
+        status, headers, body = self.make_request('/health')
+        data = json.loads(body)
+        self.assertEqual(data['terms'], 10000)
+    
+    def test_health_contains_uptime(self):
+        """Health response should contain uptime_seconds."""
+        import json
+        status, headers, body = self.make_request('/health')
+        data = json.loads(body)
+        self.assertIn('uptime_seconds', data)
+        self.assertGreaterEqual(data['uptime_seconds'], 0)
+    
+    def test_health_contains_version(self):
+        """Health response should contain version."""
+        import json
+        status, headers, body = self.make_request('/health')
+        data = json.loads(body)
+        self.assertIn('version', data)
+
+
+class TestHealthEndpointUnhealthy(ServerTestCase):
+    """Tests for /health endpoint when unhealthy."""
+    
+    @classmethod
+    def setUpClass(cls):
+        """Start test server with empty engine (no documents)."""
+        cls.engine = MockSearchEngine(stats={
+            'total_documents': 0,  # No documents = unhealthy
+            'unique_terms': 0,
+        })
+        cls.start_server(engine=cls.engine)
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Stop test server."""
+        cls.stop_server()
+    
+    def test_health_returns_503_when_unhealthy(self):
+        """GET /health should return 503 when no documents indexed."""
+        status, headers, body = self.make_request('/health')
+        self.assertEqual(status, 503)
+    
+    def test_health_contains_status_unhealthy(self):
+        """Health response should contain status: unhealthy."""
+        import json
+        status, headers, body = self.make_request('/health')
+        data = json.loads(body)
+        self.assertEqual(data['status'], 'unhealthy')
+    
+    def test_health_contains_reason(self):
+        """Unhealthy response should contain reason."""
+        import json
+        status, headers, body = self.make_request('/health')
+        data = json.loads(body)
+        self.assertIn('reason', data)
+        self.assertIn('documents', data['reason'].lower())
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
Add a health check endpoint for monitoring and load balancers.

## Changes
- Add `/health` endpoint to web server
- Return JSON response with server status
- Return 200 OK when healthy (documents indexed)
- Return 503 Service Unavailable when unhealthy (no documents)
- Add `send_json()` helper method to SearchHandler
- Track server start time for uptime calculation

## Response Format
```json
{
  "status": "ok",
  "documents": 500,
  "terms": 10000,
  "uptime_seconds": 123.4,
  "version": "1.8.2"
}
```

When unhealthy:
```json
{
  "status": "unhealthy",
  "documents": 0,
  "terms": 0,
  "uptime_seconds": 10.0,
  "version": "1.8.2",
  "reason": "No documents indexed"
}
```

## Testing
- 459 tests passing (10 new tests)
- Tests cover:
  - 200 response when healthy
  - 503 response when unhealthy
  - JSON content type
  - All fields present in response
  - Uptime tracking

Part of Phase 4 (Error Handling & Observability) from REFACTOR_PLAN.md