### PR TITLE
Phase 2.2: Extract create_permissive_ssl_context() to utils

### DIFF
--- a/doc_search/crawler.py
+++ b/doc_search/crawler.py
@@ -5,7 +5,6 @@ Supports parallel crawling with per-domain rate limiting.
 
 import json
 import time
-import ssl
 import gzip
 import hashlib
 import threading
@@ -18,7 +17,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed, TimeoutError as
 
 from .utils import (
     normalize_url, is_same_domain, url_to_filename, 
-    is_html_content, get_domain, make_basic_auth_header
+    is_html_content, get_domain, make_basic_auth_header,
+    create_permissive_ssl_context
 )
 from .robots import RobotsChecker
 from .parser import extract_text, extract_links
@@ -150,9 +150,7 @@ class Crawler:
         self.rate_limiter = RateLimiter(delay)
         
         # SSL context that doesn't verify (for self-signed certs in docs)
-        self.ssl_context = ssl.create_default_context()
-        self.ssl_context.check_hostname = False
-        self.ssl_context.verify_mode = ssl.CERT_NONE
+        self.ssl_context = create_permissive_ssl_context()
         
         # Output lock for verbose messages
         self._print_lock = threading.Lock()

--- a/doc_search/pdf_extractor.py
+++ b/doc_search/pdf_extractor.py
@@ -9,9 +9,8 @@ from typing import Optional, Dict, Any
 from io import BytesIO
 from urllib.request import Request, urlopen
 from urllib.error import URLError, HTTPError
-import ssl
 
-from .utils import make_basic_auth_header
+from .utils import make_basic_auth_header, create_permissive_ssl_context
 
 # Add vendor directory to path for PyPDF2 import
 _vendor_path = Path(__file__).parent.parent / 'vendor'
@@ -46,9 +45,7 @@ class PDFExtractor:
         self.auth_token = auth_token
         
         # SSL context for self-signed certs
-        self.ssl_context = ssl.create_default_context()
-        self.ssl_context.check_hostname = False
-        self.ssl_context.verify_mode = ssl.CERT_NONE
+        self.ssl_context = create_permissive_ssl_context()
     
     def _get_auth_header(self) -> Optional[str]:
         """Get Basic Auth header if credentials provided."""

--- a/doc_search/utils.py
+++ b/doc_search/utils.py
@@ -3,12 +3,37 @@ Utility functions for URL normalization and helpers.
 """
 
 import re
+import ssl
 import sys
 import base64
 import hashlib
 import posixpath
 from typing import Optional, Tuple
 from urllib.parse import urlparse, urlunparse, urljoin, parse_qsl, urlencode
+
+
+def create_permissive_ssl_context() -> ssl.SSLContext:
+    """
+    Create SSL context that skips certificate verification.
+    
+    This is useful for crawling documentation sites with self-signed
+    certificates or internal sites where SSL verification is not needed.
+    
+    Warning:
+        This disables SSL certificate verification, which makes connections
+        vulnerable to man-in-the-middle attacks. Only use for trusted sources.
+    
+    Returns:
+        An SSLContext configured to skip certificate verification.
+    
+    Example:
+        >>> ctx = create_permissive_ssl_context()
+        >>> urlopen(url, context=ctx)
+    """
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
 
 
 # ============================================================================

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,10 +3,12 @@ Tests for utility functions including URL normalization.
 """
 
 import base64
+import ssl
 import unittest
 from doc_search.utils import (
     normalize_url, tokenize, is_valid_url, get_domain,
-    hash_string, url_to_filename, site_hash, make_basic_auth_header
+    hash_string, url_to_filename, site_hash, make_basic_auth_header,
+    create_permissive_ssl_context
 )
 
 
@@ -353,6 +355,31 @@ class TestMakeBasicAuthHeader(unittest.TestCase):
         token = result[6:]
         decoded = base64.b64decode(token).decode()
         self.assertEqual(decoded, ":pass")
+
+
+class TestCreatePermissiveSslContext(unittest.TestCase):
+    """Tests for create_permissive_ssl_context function."""
+    
+    def test_returns_ssl_context(self):
+        """Should return an SSLContext instance."""
+        ctx = create_permissive_ssl_context()
+        self.assertIsInstance(ctx, ssl.SSLContext)
+    
+    def test_check_hostname_disabled(self):
+        """Should have hostname checking disabled."""
+        ctx = create_permissive_ssl_context()
+        self.assertFalse(ctx.check_hostname)
+    
+    def test_cert_verification_disabled(self):
+        """Should have certificate verification disabled (CERT_NONE)."""
+        ctx = create_permissive_ssl_context()
+        self.assertEqual(ctx.verify_mode, ssl.CERT_NONE)
+    
+    def test_returns_new_instance_each_call(self):
+        """Should return a new SSLContext on each call."""
+        ctx1 = create_permissive_ssl_context()
+        ctx2 = create_permissive_ssl_context()
+        self.assertIsNot(ctx1, ctx2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
Extracts the duplicated SSL context creation logic from `crawler.py` and `pdf_extractor.py` into a shared utility function in `utils.py`.

## Changes
- **`doc_search/utils.py`**: Added `create_permissive_ssl_context()` function with comprehensive docstring
- **`doc_search/crawler.py`**: Updated to import and use the shared function (removed `ssl` import)
- **`doc_search/pdf_extractor.py`**: Updated to import and use the shared function (removed `ssl` import)
- **`tests/test_utils.py`**: Added 4 tests for the new utility function

## Testing
- All 756 tests pass ✅
- No regressions

## Related
Part of Issue #77 refactoring plan (Phase 2.2)