### PR TITLE
Phase 2.6: Narrow exception handling in parser.py

### DIFF
--- a/doc_search/parser.py
+++ b/doc_search/parser.py
@@ -260,9 +260,14 @@ def extract_text(html: str, include_nav: bool = False) -> Dict[str, object]:
     
     try:
         extractor.feed(html)
-    except Exception:
-        # Handle malformed HTML gracefully
-        pass
+    except (TypeError, AssertionError) as e:
+        # TypeError: html is not a string
+        # AssertionError: internal parser assertion failure
+        # Note: HTMLParser is lenient with malformed HTML and doesn't raise
+        # parsing errors - it calls error() method instead (which we override)
+        import logging
+        logging.getLogger(__name__).debug("HTML parsing failed: %s", e)
+        # Return partial results from whatever was parsed before the error
     
     return {
         'text': extractor.get_text(),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,7 +3,8 @@ Tests for HTML parsing and link extraction.
 """
 
 import unittest
-from doc_search.parser import extract_text, extract_links
+from unittest.mock import patch, MagicMock
+from doc_search.parser import extract_text, extract_links, HTMLTextExtractor
 
 
 class TestExtractText(unittest.TestCase):
@@ -60,6 +61,39 @@ class TestExtractText(unittest.TestCase):
         result = extract_text(html)
         # Should not crash, and should extract some text
         self.assertIn('Unclosed paragraph', result['text'])
+    
+    def test_non_string_input_returns_empty(self):
+        """Should handle non-string input (TypeError) gracefully."""
+        # Passing None or other non-string types should not crash
+        result = extract_text(None)  # type: ignore
+        self.assertEqual(result['text'], '')
+        self.assertEqual(result['title'], '')
+        
+        result = extract_text(123)  # type: ignore
+        self.assertEqual(result['text'], '')
+        self.assertEqual(result['title'], '')
+        
+        result = extract_text(['<p>list</p>'])  # type: ignore
+        self.assertEqual(result['text'], '')
+        self.assertEqual(result['title'], '')
+    
+    def test_assertion_error_returns_partial(self):
+        """Should handle AssertionError gracefully and return partial results."""
+        with patch.object(HTMLTextExtractor, 'feed') as mock_feed:
+            mock_feed.side_effect = AssertionError("Internal assertion failure")
+            result = extract_text('<p>Content</p>')
+            # Should return empty/default structure without crashing
+            self.assertIn('text', result)
+            self.assertIn('title', result)
+            self.assertEqual(result['text'], '')
+    
+    def test_unhandled_exceptions_propagate(self):
+        """Verify that unexpected exceptions are not silently swallowed."""
+        with patch.object(HTMLTextExtractor, 'feed') as mock_feed:
+            # ValueError should NOT be caught - it should propagate
+            mock_feed.side_effect = ValueError("Unexpected error")
+            with self.assertRaises(ValueError):
+                extract_text('<p>Content</p>')
 
 
 class TestExtractLinks(unittest.TestCase):


### PR DESCRIPTION
## Summary
Replace broad `except Exception` in `extract_text()` with specific exception types.

## Changes
- **parser.py**: Replace `except Exception` with `except (TypeError, AssertionError)`
  - `TypeError`: Catches non-string input to `HTMLParser.feed()`
  - `AssertionError`: Catches internal parser assertion failures
  - Note: `HTMLParser` is already lenient with malformed HTML (doesn't raise)
  - Added debug logging for caught exceptions

- **test_parser.py**: Added 3 new tests:
  - `test_non_string_input_returns_empty`: Verifies None, int, list inputs handled gracefully
  - `test_assertion_error_returns_partial`: Verifies AssertionError caught, returns empty result
  - `test_unhandled_exceptions_propagate`: Verifies unexpected exceptions (e.g., ValueError) are NOT silently swallowed

## Test Results
All 759 tests pass.

Closes #81