### PR TITLE
Phase 2.8: Add site_dir validation in CLI commands

### DIFF
--- a/doc_search/cli/commands.py
+++ b/doc_search/cli/commands.py
@@ -31,15 +31,36 @@ def get_site_dir(url_or_path: str, include_path: bool = False) -> Path:
     Args:
         url_or_path: URL or existing directory path
         include_path: If True, include URL path in hash (separate storage per path)
+    
+    Returns:
+        Path to the site data directory
+    
+    Raises:
+        ValueError: If input is neither a valid URL nor an existing directory
     """
+    # Check if it's a URL (http:// or https://)
+    if url_or_path.startswith('http://') or url_or_path.startswith('https://'):
+        return DEFAULT_DATA_DIR / site_hash(url_or_path, include_path=include_path)
+    
+    # Not a URL - must be an existing directory path
     path = Path(url_or_path)
     
-    # If it's an existing directory, use it
-    if path.is_dir():
-        return path
+    # Check if path exists
+    if not path.exists():
+        raise ValueError(
+            f"Directory not found: {url_or_path}\n"
+            f"If this is a URL, it must start with http:// or https://\n"
+            f"If this is a path, the directory must exist."
+        )
     
-    # Otherwise, treat as URL and generate directory
-    return DEFAULT_DATA_DIR / site_hash(url_or_path, include_path=include_path)
+    # Check if it's actually a directory (not a file)
+    if not path.is_dir():
+        raise ValueError(
+            f"Not a directory: {url_or_path}\n"
+            f"Expected a directory path, but found a file."
+        )
+    
+    return path
 
 
 def get_auth(args) -> Tuple[Optional[Tuple[str, str]], Optional[str]]:
@@ -64,7 +85,11 @@ def get_auth(args) -> Tuple[Optional[Tuple[str, str]], Optional[str]]:
 def cmd_crawl(args):
     """Crawl a documentation site."""
     separate_paths = getattr(args, 'separate_paths', False)
-    site_dir = get_site_dir(args.url, include_path=separate_paths)
+    try:
+        site_dir = get_site_dir(args.url, include_path=separate_paths)
+    except ValueError as e:
+        print(style_error(f"Error: {e}"))
+        return 1
     site_dir.mkdir(parents=True, exist_ok=True)
     
     print(f"Crawling: {args.url}")
@@ -111,7 +136,11 @@ def cmd_crawl(args):
 def cmd_index(args):
     """Build search index from crawled pages."""
     separate_paths = getattr(args, 'separate_paths', False)
-    site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
+    try:
+        site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
+    except ValueError as e:
+        print(style_error(f"Error: {e}"))
+        return 1
     pages_dir = site_dir / 'pages'
     
     if not pages_dir.exists():
@@ -145,7 +174,11 @@ def cmd_index(args):
 def cmd_search(args):
     """Search the index with enhanced features."""
     separate_paths = getattr(args, 'separate_paths', False)
-    site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
+    try:
+        site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
+    except ValueError as e:
+        print(style_error(f"Error: {e}"))
+        return 1
     
     # Find index file
     index_path = None
@@ -274,7 +307,11 @@ def cmd_search(args):
 def cmd_autocomplete(args):
     """Get autocomplete suggestions for a prefix."""
     separate_paths = getattr(args, 'separate_paths', False)
-    site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
+    try:
+        site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
+    except ValueError as e:
+        print(style_error(f"Error: {e}"))
+        return 1
     
     # Find index file
     index_path = None
@@ -306,7 +343,11 @@ def cmd_autocomplete(args):
 def cmd_interactive(args):
     """Interactive search mode with beautiful colored output and enhanced features."""
     separate_paths = getattr(args, 'separate_paths', False)
-    site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
+    try:
+        site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
+    except ValueError as e:
+        print(style_error(f"Error: {e}"))
+        return 1
     
     # Find index file
     index_path = None
@@ -399,7 +440,11 @@ def cmd_stats(args):
     from datetime import datetime
     
     separate_paths = getattr(args, 'separate_paths', False)
-    site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
+    try:
+        site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
+    except ValueError as e:
+        print(style_error(f"Error: {e}"))
+        return 1
     
     if not site_dir.exists():
         print(f"Error: Site directory not found: {site_dir}")
@@ -524,7 +569,11 @@ def cmd_serve(args):
     from ..server import run_server
     
     separate_paths = getattr(args, 'separate_paths', False)
-    site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
+    try:
+        site_dir = get_site_dir(args.site_dir, include_path=separate_paths)
+    except ValueError as e:
+        print(style_error(f"Error: {e}"))
+        return 1
     
     # Find index file
     index_path = None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4468,5 +4468,111 @@ class TestParserShortOptions(unittest.TestCase):
 import argparse
 
 
+class TestGetSiteDirValidation(CLITestCase):
+    """Tests for get_site_dir validation (Phase 2.8)."""
+    
+    def test_get_site_dir_with_valid_http_url(self):
+        """get_site_dir should accept http:// URLs."""
+        result = get_site_dir('http://example.com/docs')
+        # Should return a path in DEFAULT_DATA_DIR
+        self.assertTrue(str(result).startswith(str(DEFAULT_DATA_DIR)))
+    
+    def test_get_site_dir_with_valid_https_url(self):
+        """get_site_dir should accept https:// URLs."""
+        result = get_site_dir('https://example.com/docs')
+        # Should return a path in DEFAULT_DATA_DIR
+        self.assertTrue(str(result).startswith(str(DEFAULT_DATA_DIR)))
+    
+    def test_get_site_dir_with_existing_directory(self):
+        """get_site_dir should accept existing directories."""
+        result = get_site_dir(str(self.site_dir))
+        self.assertEqual(result, self.site_dir)
+    
+    def test_get_site_dir_with_nonexistent_path(self):
+        """get_site_dir should raise ValueError for non-existent paths."""
+        with self.assertRaises(ValueError) as ctx:
+            get_site_dir('/nonexistent/path/to/nowhere')
+        
+        error_msg = str(ctx.exception)
+        self.assertIn('Directory not found', error_msg)
+        self.assertIn('http://', error_msg)  # Should suggest URL format
+        self.assertIn('https://', error_msg)
+    
+    def test_get_site_dir_with_file_instead_of_directory(self):
+        """get_site_dir should raise ValueError when path is a file."""
+        # Create a file in the temp directory
+        test_file = self.site_dir / 'test_file.txt'
+        test_file.write_text('test content')
+        
+        with self.assertRaises(ValueError) as ctx:
+            get_site_dir(str(test_file))
+        
+        error_msg = str(ctx.exception)
+        self.assertIn('Not a directory', error_msg)
+        self.assertIn('found a file', error_msg)
+    
+    def test_get_site_dir_with_invalid_url_scheme(self):
+        """get_site_dir should raise ValueError for non-http(s) URLs."""
+        # ftp:// is not a valid URL scheme for this tool
+        with self.assertRaises(ValueError) as ctx:
+            get_site_dir('ftp://example.com/docs')
+        
+        error_msg = str(ctx.exception)
+        self.assertIn('Directory not found', error_msg)
+
+
+class TestSiteDirValidationInCommands(CLITestCase):
+    """Tests that CLI commands properly handle site_dir validation errors."""
+    
+    def test_index_with_nonexistent_path_shows_error(self):
+        """index command should show helpful error for non-existent path."""
+        code, stdout, stderr = run_cli(['index', '/nonexistent/path'])
+        
+        self.assertEqual(code, 1)
+        self.assertIn('Directory not found', stdout)
+    
+    def test_search_with_nonexistent_path_shows_error(self):
+        """search command should show helpful error for non-existent path."""
+        code, stdout, stderr = run_cli(['search', '/nonexistent/path', 'query'])
+        
+        self.assertEqual(code, 1)
+        self.assertIn('Directory not found', stdout)
+    
+    def test_stats_with_nonexistent_path_shows_error(self):
+        """stats command should show helpful error for non-existent path."""
+        code, stdout, stderr = run_cli(['stats', '/nonexistent/path'])
+        
+        self.assertEqual(code, 1)
+        self.assertIn('Directory not found', stdout)
+    
+    def test_interactive_with_nonexistent_path_shows_error(self):
+        """interactive command should show helpful error for non-existent path."""
+        code, stdout, stderr = run_cli(['interactive', '/nonexistent/path'])
+        
+        self.assertEqual(code, 1)
+        self.assertIn('Directory not found', stdout)
+    
+    def test_autocomplete_with_nonexistent_path_shows_error(self):
+        """autocomplete command should show helpful error for non-existent path."""
+        code, stdout, stderr = run_cli(['autocomplete', '/nonexistent/path', 'prefix'])
+        
+        self.assertEqual(code, 1)
+        self.assertIn('Directory not found', stdout)
+    
+    def test_serve_with_nonexistent_path_shows_error(self):
+        """serve command should show helpful error for non-existent path."""
+        code, stdout, stderr = run_cli(['serve', '/nonexistent/path'])
+        
+        self.assertEqual(code, 1)
+        self.assertIn('Directory not found', stdout)
+    
+    def test_crawl_with_invalid_url_shows_error(self):
+        """crawl command should show helpful error for invalid URL."""
+        code, stdout, stderr = run_cli(['crawl', 'not-a-url-or-path'])
+        
+        self.assertEqual(code, 1)
+        self.assertIn('Directory not found', stdout)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
Add validation for site_dir parameter in CLI commands to provide clear error messages when the directory doesn't exist or is invalid.

## Changes
- **URL format validation**: Only accept `http://` or `https://` URLs
- **Directory existence check**: Raise ValueError if path doesn't exist (when not a URL)
- **Directory type check**: Raise ValueError if path is a file instead of directory
- **Helpful error messages**: Clear guidance on what went wrong and how to fix it
- **Command updates**: All CLI commands (crawl, index, search, stats, interactive, autocomplete, serve) now catch ValueError and display friendly errors
- **Comprehensive tests**: 13 new tests covering all validation scenarios

## Testing
All 772 tests pass.

Closes #83