### PR TITLE
Phase 2.9: Audit and fix private method naming

### DIFF
--- a/docs/api-audit-phase-2.9.md
+++ b/docs/api-audit-phase-2.9.md
@@ -1,0 +1,42 @@
+# Private Method Naming Audit - Phase 2.9
+
+This document summarizes the audit of all modules for private method naming consistency.
+
+## Audit Results
+
+All modules already follow Python's private method naming convention using underscore prefix (`_method_name`).
+
+### Summary by Module
+
+| Module | Private Methods/Attributes | Public API |
+|--------|---------------------------|------------|
+| `crawler.py` | `_log`, `_get_auth_header`, `_get_page_metadata`, `_content_hash`, `_fetch`, `_is_skippable_extension`, `_is_extractable_doc`, `_is_skippable_path`, `_is_under_base_path`, `_should_crawl`, `_save_page`, `_process_page`, `_process_document`, `_crawl_single_threaded`, `_crawl_parallel`, `_pdf_extractor`, `_print_lock`, `_stop_requested` | `crawl()`, `get_crawled_pages()` |
+| `crawl_state.py` | `_lock` | `save()`, `load()`, `clear()`, `pop_url()`, `add_urls()`, `mark_visited()`, `is_visited()`, `mark_failed()`, `increment_stat()`, `get_progress()`, `record_error()`, `get_errors()`, `get_error_summary()` |
+| `rate_limiter.py` | `_domain_delays`, `_last_request`, `_backoff_until`, `_lock` | `set_domain_delay()`, `get_delay()`, `set_backoff()`, `wait_for_domain()` |
+| `parser.py` | `_in_title`, `_title_parts`, `_ignore_depth`, `_nav_depth`, `_tag_stack`, `_current_heading`, `_heading_parts` | `reset_state()`, `get_text()`, `extract_text()`, `extract_links()` |
+| `robots.py` | `_loaded`, `_crawl_delay` | `load()`, `can_fetch()`, `get_crawl_delay()` |
+| `indexer.py` | `_update_avg_doc_length()`, `_idf()` | `add_document()`, `build_from_pages()`, `search()`, `save()`, `load()`, `get_stats()`, `get_doc_id()`, `get_document()`, `has_url()` |
+| `searcher.py` | `_load_page_text()`, `_build_enhanced_features()`, `_spellcheck_enabled`, `_autocomplete_enabled`, `_facets_enabled`, `_synonyms_enabled`, `_custom_synonym_groups`, `_spellchecker`, `_autocomplete`, `_facets`, `_synonyms` | `search()`, `search_with_context()`, `search_simple()`, `get_document()`, `get_stats()`, `get_spelling_suggestion()`, `get_autocomplete_suggestions()`, `get_facet_counts()` |
+| `stemmer.py` | `_is_consonant()`, `_measure()`, `_has_vowel()`, `_ends_double_consonant()`, `_ends_cvc()`, `_replace_suffix()`, `_step1a()` - `_step5b()` | `stem()`, `stem_tokens()` |
+| `autocomplete.py` | `_find_node()`, `_collect_words()`, `_word_count` | `add_word()`, `add_words()`, `build_from_index()`, `suggest()`, `suggest_with_scores()`, `has_prefix()`, `contains()`, `get_word_count()`, `get_frequency()` |
+| `facets.py` | `_normalize_section()` | `extract_section()`, `extract_path_facets()`, `add_document()`, `get_facet_values()`, `get_facet_counts()`, `filter_by_facet()`, `filter_by_facets()`, `get_doc_facets()`, `get_all_facet_types()`, `to_dict()`, `from_dict()`, `get_stats()` |
+| `spellcheck.py` | `_build_prefix_index()`, `_get_candidates()`, `_prefix_index` | `is_valid()`, `suggest()`, `suggest_query()`, `get_vocabulary_size()` |
+| `synonyms.py` | `_synonyms` | `add_synonym_group()`, `add_synonym_pair()`, `get_synonyms()`, `expand_terms()`, `expand_query()`, `has_synonyms()`, `get_all_terms()`, `get_synonym_count()`, `to_dict()`, `from_dict()` |
+| `pdf_extractor.py` | `_get_auth_header()`, `_fetch_pdf()` | `extract_from_file()`, `extract_from_url()`, `extract()` |
+| `cli/parsers.py` | `_add_crawl_parser()`, `_add_index_parser()`, `_add_search_parser()`, `_add_autocomplete_parser()`, `_add_interactive_parser()`, `_add_stats_parser()`, `_add_list_parser()`, `_add_serve_parser()` | `create_parser()` |
+
+### Module-Level Functions
+
+The following modules contain module-level utility functions that are intentionally public:
+
+- `utils.py` - URL normalization, tokenization, formatting utilities
+- `searcher_utils.py` - Result formatting and highlighting utilities
+- `constants.py` - Configuration constants
+
+### Conclusion
+
+**No changes required.** All private methods and attributes already follow the underscore prefix convention. The public API is well-defined and documented in docstrings.
+
+## Backward Compatibility
+
+Since no methods were renamed, backward compatibility is fully preserved.


### PR DESCRIPTION
## Summary

Completed audit of all modules for private method naming consistency as per issue #84.

## Audit Results

**Finding: No changes required.** All modules already follow Python's private method naming convention using underscore prefix (`_method_name`).

### Modules Audited

- `crawler.py` - 17 private methods/attributes ✅
- `crawl_state.py` - 1 private attribute ✅
- `rate_limiter.py` - 4 private attributes ✅
- `parser.py` - 7 private state variables ✅
- `robots.py` - 2 private attributes ✅
- `indexer.py` - 2 private methods ✅
- `searcher.py` - 11 private methods/attributes ✅
- `stemmer.py` - 11 private helper functions ✅
- `autocomplete.py` - 3 private methods/attributes ✅
- `facets.py` - 1 private method ✅
- `spellcheck.py` - 3 private methods/attributes ✅
- `synonyms.py` - 1 private attribute ✅
- `pdf_extractor.py` - 2 private methods ✅
- `cli/parsers.py` - 8 private helper functions ✅
- `utils.py`, `searcher_utils.py`, `constants.py` - public utilities ✅

### Documentation

Created `docs/api-audit-phase-2.9.md` documenting:
- Complete list of private vs public methods per module
- Public API summary for each class
- Confirmation of backward compatibility

## Testing

- [x] All 772 tests pass

Closes #84