### PR TITLE
Phase 3.1: Unify SearchEngine/EnhancedSearchEngine return types

### DIFF
--- a/doc_search/cli/commands.py
+++ b/doc_search/cli/commands.py
@@ -237,7 +237,8 @@ def cmd_search(args):
         if hasattr(args, 'filter_section') and args.filter_section:
             facet_filters['section'] = args.filter_section
         
-        response = engine.search(
+        # Use search_enhanced() to get the dict response with metadata
+        response = engine.search_enhanced(
             args.query, 
             top_k=args.limit,
             facet_filters=facet_filters if facet_filters else None,
@@ -402,9 +403,9 @@ def cmd_interactive(args):
             print(style_info("\nGoodbye! 👋"))
             break
         
-        # Time the search
+        # Time the search (use search_enhanced for dict response with metadata)
         start_time = time.perf_counter()
-        response = engine.search(query, top_k=args.limit)
+        response = engine.search_enhanced(query, top_k=args.limit)
         elapsed_ms = (time.perf_counter() - start_time) * 1000
         
         results = response['results']

--- a/doc_search/searcher.py
+++ b/doc_search/searcher.py
@@ -250,6 +250,11 @@ class EnhancedSearchEngine(SearchEngine):
     - Autocomplete / type-ahead suggestions
     - Faceted search (filter by section/type)
     - Query expansion with synonyms (disabled by default)
+    
+    Note: The search() method returns List[Dict[str, Any]] for LSP compliance
+    with SearchEngine. Enhanced metadata (suggestion, facets, etc.) is stored
+    in instance attributes after each search, or use search_enhanced() for
+    a dict response containing all metadata.
     """
     
     def __init__(self, index: BM25Index, pages_dir: Optional[Path] = None,
@@ -283,6 +288,12 @@ class EnhancedSearchEngine(SearchEngine):
         self._autocomplete: Optional[Autocomplete] = None
         self._facets: Optional[FacetIndex] = None
         self._synonyms: Optional[SynonymExpander] = None
+        
+        # Last search metadata (populated after each search() call)
+        self.last_suggestion: Optional[str] = None
+        self.last_facets: Dict[str, Dict[str, int]] = {}
+        self.last_query: str = ''
+        self.last_expanded_query: Optional[str] = None
         
         # Build enhanced features from index
         self._build_enhanced_features()
@@ -418,9 +429,15 @@ class EnhancedSearchEngine(SearchEngine):
         snippet_length: int = 150,
         facet_filters: Optional[Dict[str, str]] = None,
         expand_synonyms: bool = True
-    ) -> Dict[str, Any]:
+    ) -> List[Dict[str, Any]]:
         """
-        Enhanced search with additional features.
+        Search the index with enhanced features.
+        
+        Returns the same type as SearchEngine.search() for LSP compliance.
+        Enhanced metadata (suggestion, facets, expanded_query) is stored in
+        instance attributes: last_suggestion, last_facets, last_expanded_query.
+        
+        Use search_enhanced() to get a dict response with all metadata included.
         
         Args:
             query: Search query
@@ -432,34 +449,32 @@ class EnhancedSearchEngine(SearchEngine):
             expand_synonyms: Whether to expand query with synonyms
             
         Returns:
-            Dict with 'results', 'suggestion', 'facets' keys
+            List of result dictionaries (same as SearchEngine.search())
         """
-        response: Dict[str, Any] = {
-            'results': [],
-            'suggestion': None,
-            'facets': {},
-            'query': query,
-            'expanded_query': None
-        }
+        # Reset last search metadata
+        self.last_suggestion = None
+        self.last_facets = {}
+        self.last_query = query
+        self.last_expanded_query = None
         
         # Parse query
         terms, phrases = parse_query(query)
         
         if not terms and not phrases:
-            return response
+            return []
         
         # Check for spelling suggestions
         if self._spellchecker:
             suggestion = self.get_spelling_suggestion(query)
             if suggestion and suggestion.lower() != query.lower():
-                response['suggestion'] = suggestion
+                self.last_suggestion = suggestion
         
         # Expand query with synonyms
         expanded_terms = list(terms)
         if expand_synonyms and self._synonyms and terms:
             expanded_terms = self._synonyms.expand_terms(terms, max_per_term=2)
             if expanded_terms != list(terms):
-                response['expanded_query'] = ' '.join(expanded_terms)
+                self.last_expanded_query = ' '.join(expanded_terms)
         
         # Flatten phrases into terms for BM25 scoring
         all_terms = list(expanded_terms)
@@ -540,22 +555,66 @@ class EnhancedSearchEngine(SearchEngine):
             if len(results) >= top_k:
                 break
         
-        response['results'] = results
-        
         # Get facet counts for results
         if self._facets and results:
-            response['facets'] = self.get_facet_counts(results)
+            self.last_facets = self.get_facet_counts(results)
         
-        return response
+        return results
+    
+    def search_enhanced(
+        self, 
+        query: str, 
+        top_k: int = 10,
+        min_score: float = 0.0,
+        highlight: bool = True,
+        snippet_length: int = 150,
+        facet_filters: Optional[Dict[str, str]] = None,
+        expand_synonyms: bool = True
+    ) -> Dict[str, Any]:
+        """
+        Enhanced search that returns a dict with results and metadata.
+        
+        This is a convenience method that calls search() and packages the
+        results with the metadata stored in instance attributes.
+        
+        Args:
+            query: Search query
+            top_k: Maximum results
+            min_score: Minimum score threshold
+            highlight: Highlight query terms
+            snippet_length: Target snippet length
+            facet_filters: Optional facet filters (type -> value)
+            expand_synonyms: Whether to expand query with synonyms
+            
+        Returns:
+            Dict with 'results', 'suggestion', 'facets', 'query', 'expanded_query' keys
+        """
+        results = self.search(
+            query=query,
+            top_k=top_k,
+            min_score=min_score,
+            highlight=highlight,
+            snippet_length=snippet_length,
+            facet_filters=facet_filters,
+            expand_synonyms=expand_synonyms
+        )
+        
+        return {
+            'results': results,
+            'suggestion': self.last_suggestion,
+            'facets': self.last_facets,
+            'query': self.last_query,
+            'expanded_query': self.last_expanded_query
+        }
     
     def search_simple(self, query: str, top_k: int = 10, **kwargs) -> List[Dict[str, Any]]:
         """
         Simple search that returns just results (like base SearchEngine).
         
-        For backward compatibility.
+        Deprecated: Use search() directly, which now returns List[Dict[str, Any]].
+        This method is kept for backward compatibility.
         """
-        response = self.search(query, top_k=top_k, **kwargs)
-        return response['results']
+        return self.search(query, top_k=top_k, **kwargs)
     
     def get_stats(self) -> Dict[str, Any]:
         """Get enhanced search engine statistics."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,8 +64,13 @@ class MockSearchEngine:
         self.search_calls: List[Dict[str, Any]] = []
         self.autocomplete_calls: List[Dict[str, Any]] = []
     
-    def search(self, query: str, top_k: int = 10, **kwargs) -> Dict[str, Any]:
-        """Return mock search results in enhanced format."""
+    def search(self, query: str, top_k: int = 10, **kwargs) -> List[Dict[str, Any]]:
+        """Return mock search results as list (like SearchEngine.search)."""
+        self.search_calls.append({'query': query, 'top_k': top_k, **kwargs})
+        return self._results[:top_k]
+    
+    def search_enhanced(self, query: str, top_k: int = 10, **kwargs) -> Dict[str, Any]:
+        """Return mock search results in enhanced format (like EnhancedSearchEngine.search_enhanced)."""
         self.search_calls.append({'query': query, 'top_k': top_k, **kwargs})
         return {
             'results': self._results[:top_k],
@@ -325,7 +330,7 @@ class TestCLITestInfrastructure(CLITestCase):
         self.assertTrue(self.site_dir.exists())
     
     def test_mock_search_engine_search(self):
-        """MockSearchEngine.search should return expected format."""
+        """MockSearchEngine.search should return list (like base SearchEngine)."""
         results = [
             {'url': 'https://example.com/1', 'title': 'Page 1', 'score': 1.5},
             {'url': 'https://example.com/2', 'title': 'Page 2', 'score': 1.2},
@@ -334,9 +339,23 @@ class TestCLITestInfrastructure(CLITestCase):
         
         response = engine.search('test query', top_k=5)
         
+        # search() now returns list for LSP compliance
+        self.assertIsInstance(response, list)
+        self.assertEqual(len(response), 2)
+        self.assertEqual(engine.search_calls[0]['query'], 'test query')
+    
+    def test_mock_search_engine_search_enhanced(self):
+        """MockSearchEngine.search_enhanced should return expected dict format."""
+        results = [
+            {'url': 'https://example.com/1', 'title': 'Page 1', 'score': 1.5},
+            {'url': 'https://example.com/2', 'title': 'Page 2', 'score': 1.2},
+        ]
+        engine = MockSearchEngine(results=results)
+        
+        response = engine.search_enhanced('test query', top_k=5)
+        
         self.assertIn('results', response)
         self.assertEqual(len(response['results']), 2)
-        self.assertEqual(engine.search_calls[0]['query'], 'test query')
     
     def test_mock_search_engine_stats(self):
         """MockSearchEngine.get_stats should return stats dict."""
@@ -1573,17 +1592,17 @@ class TestCmdSearch(CLITestCase):
     def test_search_with_show_facets(self):
         """Should display facets when --show-facets flag is set."""
         mock_engine = MockSearchEngine()
-        # Override search to return facets
+        # Override search_enhanced to return facets
         facets = {
             'category': {'api': 5, 'guide': 3},
             'section': {'intro': 4, 'advanced': 4}
         }
-        original_search = mock_engine.search
-        def search_with_facets(query, top_k=10, **kwargs):
-            result = original_search(query, top_k, **kwargs)
+        original_search_enhanced = mock_engine.search_enhanced
+        def search_enhanced_with_facets(query, top_k=10, **kwargs):
+            result = original_search_enhanced(query, top_k, **kwargs)
             result['facets'] = facets
             return result
-        mock_engine.search = search_with_facets
+        mock_engine.search_enhanced = search_enhanced_with_facets
         
         self.create_mock_index()
         
@@ -1606,12 +1625,12 @@ class TestCmdSearch(CLITestCase):
         facets = {
             'category': {'api': 5, 'guide': 3}
         }
-        original_search = mock_engine.search
-        def search_with_facets(query, top_k=10, **kwargs):
-            result = original_search(query, top_k, **kwargs)
+        original_search_enhanced = mock_engine.search_enhanced
+        def search_enhanced_with_facets(query, top_k=10, **kwargs):
+            result = original_search_enhanced(query, top_k, **kwargs)
             result['facets'] = facets
             return result
-        mock_engine.search = search_with_facets
+        mock_engine.search_enhanced = search_enhanced_with_facets
         
         self.create_mock_index()
         
@@ -3165,15 +3184,15 @@ class TestCmdSearchIntegration(CLITestCase):
     def test_search_with_suggestion_in_response(self):
         """Should handle search response with spelling suggestion."""
         mock_engine = MockSearchEngine()
-        # Override search to return a suggestion
-        def search_with_suggestion(query, top_k=10, **kwargs):
+        # Override search_enhanced to return a suggestion
+        def search_enhanced_with_suggestion(query, top_k=10, **kwargs):
             return {
                 'results': [],
                 'suggestion': 'python',  # Did you mean?
                 'expanded_query': None,
                 'facets': {}
             }
-        mock_engine.search = search_with_suggestion
+        mock_engine.search_enhanced = search_enhanced_with_suggestion
         
         self.create_mock_index()
         
@@ -3193,14 +3212,14 @@ class TestCmdSearchIntegration(CLITestCase):
     def test_search_json_output_includes_suggestion(self):
         """Should include suggestion in JSON output when available."""
         mock_engine = MockSearchEngine()
-        def search_with_suggestion(query, top_k=10, **kwargs):
+        def search_enhanced_with_suggestion(query, top_k=10, **kwargs):
             return {
                 'results': [],
                 'suggestion': 'corrected_query',
                 'expanded_query': None,
                 'facets': {}
             }
-        mock_engine.search = search_with_suggestion
+        mock_engine.search_enhanced = search_enhanced_with_suggestion
         
         self.create_mock_index()
         
@@ -3221,14 +3240,14 @@ class TestCmdSearchIntegration(CLITestCase):
     def test_search_json_output_includes_expanded_query(self):
         """Should include expanded_query in JSON output when synonyms used."""
         mock_engine = MockSearchEngine()
-        def search_with_expansion(query, top_k=10, **kwargs):
+        def search_enhanced_with_expansion(query, top_k=10, **kwargs):
             return {
                 'results': [],
                 'suggestion': None,
                 'expanded_query': 'quick fast speedy',
                 'facets': {}
             }
-        mock_engine.search = search_with_expansion
+        mock_engine.search_enhanced = search_enhanced_with_expansion
         
         self.create_mock_index()
         

--- a/tests/test_enhanced_search.py
+++ b/tests/test_enhanced_search.py
@@ -78,24 +78,41 @@ class TestEnhancedSearchEngine(unittest.TestCase):
     
     def test_basic_search(self):
         """Basic search should work."""
-        response = self.engine.search('python classes')
+        results = self.engine.search('python classes')
         
-        self.assertIn('results', response)
-        self.assertTrue(len(response['results']) > 0)
+        self.assertIsInstance(results, list)
+        self.assertTrue(len(results) > 0)
         
         # First result should be about classes
-        first = response['results'][0]
+        first = results[0]
         self.assertIn('classes', first['title'].lower())
     
-    def test_search_returns_dict(self):
-        """Search should return dict with expected keys."""
-        response = self.engine.search('python')
+    def test_search_returns_list(self):
+        """Search should return list for LSP compliance with SearchEngine."""
+        results = self.engine.search('python')
+        
+        self.assertIsInstance(results, list)
+        if results:
+            self.assertIn('url', results[0])
+            self.assertIn('title', results[0])
+    
+    def test_search_enhanced_returns_dict(self):
+        """search_enhanced should return dict with expected keys."""
+        response = self.engine.search_enhanced('python')
         
         self.assertIsInstance(response, dict)
         self.assertIn('results', response)
         self.assertIn('suggestion', response)
         self.assertIn('facets', response)
         self.assertIn('query', response)
+    
+    def test_last_metadata_attributes(self):
+        """Search should populate last_* instance attributes."""
+        self.engine.search('python')
+        
+        self.assertEqual(self.engine.last_query, 'python')
+        self.assertIsInstance(self.engine.last_facets, dict)
+        # last_suggestion may be None if no typo
     
     def test_spelling_suggestion(self):
         """Should suggest corrections for misspelled queries."""
@@ -128,28 +145,30 @@ class TestEnhancedSearchEngine(unittest.TestCase):
     def test_facet_filter(self):
         """Should filter results by facet."""
         # Get all results first
-        all_response = self.engine.search('python')
-        all_count = len(all_response['results'])
+        all_results = self.engine.search('python')
+        all_count = len(all_results)
         
         # Filter by category (from URL path)
-        filtered_response = self.engine.search(
+        filtered_results = self.engine.search(
             'python',
             facet_filters={'category': 'tutorial'}
         )
         
         # Filtered should have fewer or equal results
-        self.assertLessEqual(len(filtered_response['results']), all_count)
+        self.assertLessEqual(len(filtered_results), all_count)
     
     def test_synonym_expansion(self):
         """Search should expand synonyms."""
-        response = self.engine.search('function', expand_synonyms=True)
+        results = self.engine.search('function', expand_synonyms=True)
         
-        # Check if expanded_query is set (if synonyms were found)
-        # The response should still work
-        self.assertIn('results', response)
+        # The search should return results
+        self.assertIsInstance(results, list)
+        
+        # Check if expanded_query is set via attribute
+        # (may be None if no synonyms found)
     
     def test_search_simple_backward_compat(self):
-        """search_simple should return just results list."""
+        """search_simple should return just results list (same as search now)."""
         results = self.engine.search_simple('python')
         
         self.assertIsInstance(results, list)
@@ -186,13 +205,13 @@ class TestEnhancedSearchEngineDisabledFeatures(unittest.TestCase):
     
     def test_search_with_disabled_features(self):
         """Search should work with features disabled."""
-        response = self.engine.search('test')
+        results = self.engine.search('test')
         
-        self.assertIn('results', response)
+        self.assertIsInstance(results, list)
         # No suggestion when spellcheck disabled
-        self.assertIsNone(response['suggestion'])
+        self.assertIsNone(self.engine.last_suggestion)
         # Empty facets when facets disabled
-        self.assertEqual(response['facets'], {})
+        self.assertEqual(self.engine.last_facets, {})
     
     def test_autocomplete_when_disabled(self):
         """Autocomplete should return empty when disabled."""
@@ -233,33 +252,33 @@ class TestEnhancedSearchEngineIntegration(unittest.TestCase):
     
     def test_combined_features(self):
         """Test multiple features in one search."""
-        response = self.engine.search('functoin', expand_synonyms=True)
+        results = self.engine.search('functoin', expand_synonyms=True)
         
         # Should have results (even with typo if synonym helps)
-        self.assertIn('results', response)
+        self.assertIsInstance(results, list)
         
-        # Should have suggestion for typo
-        if response['suggestion']:
-            self.assertNotEqual(response['suggestion'], 'functoin')
+        # Should have suggestion for typo (accessed via attribute)
+        if self.engine.last_suggestion:
+            self.assertNotEqual(self.engine.last_suggestion, 'functoin')
     
     def test_faceted_search_workflow(self):
         """Test typical faceted search workflow."""
         # 1. Initial search
-        response1 = self.engine.search('reference')
+        self.engine.search('reference')
         
-        # 2. Get available facets
-        facets = response1['facets']
+        # 2. Get available facets from last search
+        facets = self.engine.last_facets
         
         # 3. Apply filter if we have facets
         if facets and 'category' in facets:
             first_category = list(facets['category'].keys())[0]
-            response2 = self.engine.search(
+            filtered_results = self.engine.search(
                 'reference',
                 facet_filters={'category': first_category}
             )
             
             # Should have results
-            self.assertIn('results', response2)
+            self.assertIsInstance(filtered_results, list)
     
     def test_autocomplete_workflow(self):
         """Test autocomplete -> search workflow."""
@@ -269,8 +288,8 @@ class TestEnhancedSearchEngineIntegration(unittest.TestCase):
         # 2. User selects a suggestion or continues typing
         if suggestions:
             query = suggestions[0]
-            response = self.engine.search(query)
-            self.assertIn('results', response)
+            results = self.engine.search(query)
+            self.assertIsInstance(results, list)
 
 
 if __name__ == '__main__':

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -330,9 +330,13 @@ class TestCrawlIndexSearchWorkflow(unittest.TestCase):
             enable_synonyms=False
         )
         
-        # Test enhanced search
-        response = engine.search('python programming', top_k=5)
+        # Test enhanced search (search returns list, search_enhanced returns dict)
+        results = engine.search('python programming', top_k=5)
+        self.assertIsInstance(results, list)
+        self.assertGreater(len(results), 0)
         
+        # Test search_enhanced for full response with metadata
+        response = engine.search_enhanced('python programming', top_k=5)
         self.assertIn('results', response)
         self.assertIn('suggestion', response)
         self.assertIn('facets', response)


### PR DESCRIPTION
## Summary
This PR unifies the return types between SearchEngine and EnhancedSearchEngine to ensure Liskov Substitution Principle (LSP) compliance.

## Changes
- **EnhancedSearchEngine.search()** now returns `List[Dict[str, Any]]` (same as parent class)
- Added **search_enhanced()** method that returns a dict with full metadata:
  - `results`: List of search results
  - `suggestion`: Spelling suggestion (if available)
  - `facets`: Facet counts
  - `query`: Original query
  - `expanded_query`: Query after synonym expansion (if available)
- Added instance attributes (`last_suggestion`, `last_facets`, `last_query`, `last_expanded_query`) for accessing metadata after calling `search()`
- Updated CLI to use `search_enhanced()` when full response metadata is needed
- `search_simple()` remains for backward compatibility (now just an alias for `search()`)

## Approach Chosen
Made both return consistent types (List) rather than using composition. This:
- Maintains inheritance relationship
- Satisfies LSP (EnhancedSearchEngine is now substitutable for SearchEngine)
- Provides `search_enhanced()` for users who need the richer response

## Testing
All 775 tests pass.

Closes #85