### PR TITLE
Phase 3.2: Add deprecation warning for old API

### DIFF
--- a/doc_search/searcher.py
+++ b/doc_search/searcher.py
@@ -5,6 +5,7 @@ Search interface for querying the BM25 index.
 import json
 import re
 import time
+import warnings
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Set, Tuple
 
@@ -611,9 +612,19 @@ class EnhancedSearchEngine(SearchEngine):
         """
         Simple search that returns just results (like base SearchEngine).
         
-        Deprecated: Use search() directly, which now returns List[Dict[str, Any]].
-        This method is kept for backward compatibility.
+        .. deprecated:: 1.9.0
+            Use :meth:`search` directly, which now returns ``List[Dict[str, Any]]``.
+            This method will be removed in version 2.0.0.
+        
+        Migration:
+            Replace ``engine.search_simple(query)`` with ``engine.search(query)``.
         """
+        warnings.warn(
+            "search_simple() is deprecated and will be removed in version 2.0.0. "
+            "Use search() directly, which now returns List[Dict[str, Any]].",
+            DeprecationWarning,
+            stacklevel=2
+        )
         return self.search(query, top_k=top_k, **kwargs)
     
     def get_stats(self) -> Dict[str, Any]:

--- a/tests/test_enhanced_search.py
+++ b/tests/test_enhanced_search.py
@@ -5,6 +5,7 @@ Tests for the EnhancedSearchEngine with all 4 new features.
 import unittest
 import tempfile
 import json
+import warnings
 from pathlib import Path
 
 from doc_search.indexer import BM25Index
@@ -169,12 +170,27 @@ class TestEnhancedSearchEngine(unittest.TestCase):
     
     def test_search_simple_backward_compat(self):
         """search_simple should return just results list (same as search now)."""
-        results = self.engine.search_simple('python')
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            results = self.engine.search_simple('python')
         
         self.assertIsInstance(results, list)
         if results:
             self.assertIn('url', results[0])
             self.assertIn('title', results[0])
+    
+    def test_search_simple_deprecation_warning(self):
+        """search_simple should emit a DeprecationWarning."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.engine.search_simple('python')
+            
+            # Check that a DeprecationWarning was raised
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+            self.assertIn('search_simple', str(w[0].message))
+            self.assertIn('deprecated', str(w[0].message))
+            self.assertIn('2.0.0', str(w[0].message))
     
     def test_enhanced_stats(self):
         """Should return enhanced statistics."""


### PR DESCRIPTION
## Summary
This PR adds deprecation warnings to legacy API methods that should be phased out.

## Changes
- Added `warnings.warn()` with `DeprecationWarning` to `search_simple()` method
- Updated docstring with Sphinx-style deprecation notice and migration guidance
- Added test to verify deprecation warning is raised correctly

## Deprecated Methods
| Method | Replacement | Removal Version |
|--------|-------------|-----------------|
| `search_simple()` | `search()` | 2.0.0 |

## Migration Example
```python
# Before (deprecated)
results = engine.search_simple(query)

# After
results = engine.search(query)
```

## Testing
All 776 tests pass.

Closes #86