### PR TITLE
Phase 3.3: Update CLI callers to use unified API

### DIFF
--- a/doc_search/cli/commands.py
+++ b/doc_search/cli/commands.py
@@ -3,6 +3,16 @@ Command implementations for doc-search CLI.
 
 This module contains all the cmd_* functions that implement
 the various CLI commands (crawl, index, search, etc.).
+
+API Usage:
+    All CLI commands use the unified search API:
+    - cmd_search: Uses EnhancedSearchEngine.search_enhanced() or SearchEngine.search()
+    - cmd_serve: Uses SearchEngine.search() via the web server
+    - cmd_autocomplete: Uses EnhancedSearchEngine.get_autocomplete_suggestions()
+    - cmd_interactive: Uses EnhancedSearchEngine.search_enhanced()
+    - cmd_stats: Uses SearchEngine.get_stats()
+    
+    Note: The deprecated search_simple() method is NOT used by the CLI.
 """
 
 import getpass


### PR DESCRIPTION
## Summary
Verified and documented that all CLI commands use the unified search API.

## Changes
- Added module-level documentation in `commands.py` explicitly stating which API methods each command uses

## Verification
The CLI was already using the unified API correctly:
- `cmd_search`: Uses `EnhancedSearchEngine.search_enhanced()` or `SearchEngine.search()`
- `cmd_serve`: Uses `SearchEngine.search()` via the web server
- `cmd_autocomplete`: Uses `EnhancedSearchEngine.get_autocomplete_suggestions()`
- `cmd_interactive`: Uses `EnhancedSearchEngine.search_enhanced()`
- `cmd_stats`: Uses `SearchEngine.get_stats()`

The deprecated `search_simple()` method is NOT used anywhere in the CLI.

## Checklist from Issue #87
- [x] Update cmd_search to use new API (already compliant)
- [x] Update cmd_serve to use new API (already compliant)
- [x] Update any other callers (all already compliant)
- [x] Verify JSON output format is unchanged (verified via tests)
- [x] All tests pass (776 passed)

Closes #87