### PR TITLE
Phase 4.1: Optimize CrawlState.add_urls() with persistent set

### DIFF
--- a/doc_search/crawl_state.py
+++ b/doc_search/crawl_state.py
@@ -51,6 +51,7 @@ class CrawlState:
         self.state_file = state_file
         self.visited: Set[str] = set()
         self.pending: deque = deque()  # (url, depth) tuples
+        self._pending_set: Set[str] = set()  # O(1) lookup for pending URLs
         self.failed: Dict[str, int] = {}  # url -> retry count
         self.errors: List[CrawlError] = []  # Structured error tracking
         self.stats = {
@@ -96,11 +97,14 @@ class CrawlState:
                 # Handle both old format (just urls) and new format (url, depth tuples)
                 pending = state.get('pending', [])
                 self.pending = deque()
+                self._pending_set = set()
                 for item in pending:
                     if isinstance(item, list) and len(item) == 2:
                         self.pending.append(tuple(item))
+                        self._pending_set.add(item[0])
                     else:
                         self.pending.append((item, 0))  # Assume depth 0 for old format
+                        self._pending_set.add(item)
                 self.failed = state.get('failed', {})
                 # Restore errors from state
                 self.errors = [
@@ -116,6 +120,7 @@ class CrawlState:
         with self._lock:
             self.visited.clear()
             self.pending.clear()
+            self._pending_set.clear()
             self.failed.clear()
             self.errors.clear()
             self.stats = {
@@ -137,19 +142,19 @@ class CrawlState:
             if self.pending:
                 item = self.pending.popleft()
                 if isinstance(item, tuple):
+                    self._pending_set.discard(item[0])
                     return item
+                self._pending_set.discard(item)
                 return (item, 0)
             return None
     
     def add_urls(self, urls: List[Tuple[str, int]]):
         """Add URLs to the queue (thread-safe), avoiding duplicates."""
         with self._lock:
-            # Build set of URLs already in pending for fast lookup
-            pending_urls = {url for url, _ in self.pending}
             for url, depth in urls:
-                if url not in self.visited and url not in pending_urls:
+                if url not in self.visited and url not in self._pending_set:
                     self.pending.append((url, depth))
-                    pending_urls.add(url)
+                    self._pending_set.add(url)
     
     def mark_visited(self, url: str):
         """Mark a URL as visited (thread-safe)."""
@@ -171,6 +176,7 @@ class CrawlState:
             if retry_count < 3:
                 self.failed[url] = retry_count + 1
                 self.pending.append((url, depth))
+                self._pending_set.add(url)
                 self.visited.discard(url)
                 return True
             else:

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -827,6 +827,75 @@ class TestCrawlError(CrawlerTestCase):
         # Should be valid JSON
         parsed = json.loads(json_str)
         self.assertEqual(parsed['url'], error.url)
+    
+    # -------------------------------------------------------------------------
+    # Performance tests for persistent set optimization
+    # -------------------------------------------------------------------------
+    
+    def test_add_urls_performance_with_large_queue(self):
+        """add_urls should maintain O(1) lookup even with large pending queue.
+        
+        This tests the optimization from Phase 4.1 (#88) - using a persistent
+        _pending_set instead of rebuilding the set on every add_urls call.
+        """
+        import time
+        state = self.create_crawl_state()
+        
+        # Pre-populate with 10K URLs
+        initial_urls = [(f'https://example.com/page{i}', 0) for i in range(10000)]
+        state.add_urls(initial_urls)
+        
+        # Now benchmark adding more URLs
+        # With O(n) set construction, this would be slow
+        # With O(1) persistent set, this should be fast
+        new_urls = [(f'https://example.com/new{i}', 0) for i in range(1000)]
+        
+        start = time.time()
+        for i in range(10):  # 10 batches
+            batch = [(f'https://example.com/batch{i}-{j}', 0) for j in range(100)]
+            state.add_urls(batch)
+        elapsed = time.time() - start
+        
+        # Should complete in under 100ms (with old O(n) impl would be slower)
+        self.assertLess(elapsed, 0.1, f"add_urls too slow: {elapsed:.3f}s")
+        
+        # Verify correctness - all URLs should be in pending
+        self.assertEqual(len(state.pending), 11000)  # 10K + 10*100
+    
+    def test_pending_set_consistency_with_pop(self):
+        """_pending_set should stay consistent when popping URLs."""
+        state = self.create_crawl_state()
+        
+        # Add some URLs
+        urls = [(f'https://example.com/page{i}', 0) for i in range(5)]
+        state.add_urls(urls)
+        
+        # Pop some URLs
+        state.pop_url()
+        state.pop_url()
+        
+        # Try to re-add the same URLs - only popped ones should be added
+        state.add_urls(urls)
+        
+        # Should have 5 (original 3 still pending) + 2 (re-added popped ones)
+        self.assertEqual(len(state.pending), 5)
+    
+    def test_pending_set_consistency_with_mark_failed(self):
+        """_pending_set should stay consistent when mark_failed re-adds URLs."""
+        state = self.create_crawl_state()
+        
+        # Add and pop a URL
+        state.add_urls([('https://example.com/fail', 0)])
+        url, depth = state.pop_url()
+        
+        # Mark it as failed (should re-add to pending)
+        state.mark_failed(url, depth)
+        
+        # Try to add the same URL again - should be skipped (already in pending)
+        state.add_urls([('https://example.com/fail', 0)])
+        
+        # Should only have 1 URL in pending
+        self.assertEqual(len(state.pending), 1)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
Optimizes `CrawlState.add_urls()` to use a persistent `_pending_set` for O(1) URL deduplication lookups instead of rebuilding the set on every call (O(n)).

## Changes
- **`_pending_set: Set[str]`** - New attribute tracking pending URLs
- **`add_urls()`** - Uses persistent set for O(1) duplicate checking
- **`pop_url()`** - Removes URL from `_pending_set` when popped
- **`mark_failed()`** - Adds URL back to `_pending_set` when retrying
- **`clear()`** - Resets `_pending_set`
- **`load()`** - Rebuilds `_pending_set` from pending deque

## Performance
Benchmark with 10K+ URLs shows add_urls completes in <100ms (vs O(n²) behavior before).

## Tests
- `test_add_urls_performance_with_large_queue` - Performance test with 10K URLs
- `test_pending_set_consistency_with_pop` - Consistency after popping
- `test_pending_set_consistency_with_mark_failed` - Consistency after failed retry

All 779 tests pass.

Closes #88