### PR TITLE
Phase 6.2: Extract URL filtering into url_filter.py module

### DIFF
--- a/doc_search/crawler/__init__.py
+++ b/doc_search/crawler/__init__.py
@@ -4,13 +4,18 @@ Crawler package for doc-search.
 Re-exports Crawler from _crawler for backward compatibility.
 """
 
-from ._crawler import (
-    Crawler,
+from ._crawler import Crawler
+from .fetcher import Fetcher, FetchResult
+from .url_filter import (
     SKIP_EXTENSIONS,
     EXTRACTABLE_DOC_EXTENSIONS,
     SKIP_PATH_PATTERNS,
+    UrlFilter,
+    is_skippable_extension,
+    is_extractable_doc,
+    is_skippable_path,
+    is_under_base_path,
 )
-from .fetcher import Fetcher, FetchResult
 from ..rate_limiter import RateLimiter
 
 __all__ = [
@@ -18,7 +23,12 @@ __all__ = [
     'Fetcher',
     'FetchResult',
     'RateLimiter',
+    'UrlFilter',
     'SKIP_EXTENSIONS',
     'EXTRACTABLE_DOC_EXTENSIONS',
     'SKIP_PATH_PATTERNS',
+    'is_skippable_extension',
+    'is_extractable_doc',
+    'is_skippable_path',
+    'is_under_base_path',
 ]

--- a/doc_search/crawler/_crawler.py
+++ b/doc_search/crawler/_crawler.py
@@ -26,48 +26,12 @@ from ..constants import (
 from ..crawl_state import CrawlState
 from ..rate_limiter import RateLimiter
 from .fetcher import Fetcher
-
-
-# Extensions that should never be crawled (archives, media, binaries)
-SKIP_EXTENSIONS = frozenset([
-    # Archives
-    '.tar', '.gz', '.tgz', '.tar.gz', '.tar.bz2', '.tar.xz',
-    '.zip', '.rar', '.7z', '.bz2', '.xz', '.lz', '.lzma',
-    # Documents (excluded by default, can be enabled with extract_docs=True)
-    '.epub', '.mobi', '.ppt', '.pptx', '.odt', '.ods', '.odp',
-    # Images
-    '.jpg', '.jpeg', '.png', '.gif', '.svg', '.ico', '.webp',
-    '.bmp', '.tiff', '.tif', '.psd', '.ai', '.eps',
-    # Media
-    '.mp3', '.mp4', '.avi', '.mov', '.wmv', '.flv', '.mkv',
-    '.wav', '.ogg', '.webm', '.m4a', '.m4v',
-    # Code/data files (usually not documentation)
-    '.css', '.js', '.json', '.xml', '.rss', '.atom',
-    '.woff', '.woff2', '.ttf', '.eot', '.otf',
-    # Executables and packages
-    '.exe', '.msi', '.dmg', '.pkg', '.deb', '.rpm',
-    '.whl', '.egg', '.jar', '.war', '.apk', '.ipa',
-    # Source archives
-    '.asc', '.sig', '.sha256', '.md5',
-])
-
-# Document extensions that can be extracted (when extract_docs=True)
-EXTRACTABLE_DOC_EXTENSIONS = frozenset([
-    '.pdf',
-    '.doc', '.docx',
-    '.xls', '.xlsx',
-])
-
-# URL path patterns that indicate non-documentation content
-SKIP_PATH_PATTERNS = [
-    '/download/', '/downloads/',
-    '/archive/', '/archives/',
-    '/releases/', '/release/',
-    '/dist/', '/ftp/',
-    '/source/', '/sources/',
-    '/packages/', '/pkg/',
-    '/binaries/', '/bin/',
-]
+from .url_filter import (
+    SKIP_EXTENSIONS,
+    EXTRACTABLE_DOC_EXTENSIONS,
+    SKIP_PATH_PATTERNS,
+    UrlFilter,
+)
 
 
 class Crawler:
@@ -168,6 +132,20 @@ class Crawler:
             log_func=self._log,
             stats_callback=self._update_stat
         )
+        
+        # Initialize URL filter
+        self._url_filter = UrlFilter(
+            base_url=base_url,
+            robots_checker=self.robots,
+            stay_on_domain=stay_on_domain,
+            same_path=same_path,
+            extract_docs=extract_docs,
+            max_depth=max_depth,
+            url_filter=url_filter,
+        )
+        # Sync base_path and same_path from UrlFilter (it may adjust for root paths)
+        self.base_path = self._url_filter.base_path
+        self.same_path = self._url_filter.same_path
     
     def _log(self, message: str):
         """Print message if verbose mode is enabled (thread-safe)."""
@@ -215,102 +193,28 @@ class Crawler:
     
     def _is_skippable_extension(self, url: str) -> bool:
         """Check if URL has an extension that should be skipped."""
-        parsed = urlparse(url)
-        path = parsed.path.lower()
-        
-        # Check each skip extension
-        for ext in SKIP_EXTENSIONS:
-            if path.endswith(ext):
-                return True
-        
-        # Check extractable document extensions
-        # Skip them unless extract_docs is enabled
-        if not self.extract_docs:
-            for ext in EXTRACTABLE_DOC_EXTENSIONS:
-                if path.endswith(ext):
-                    return True
-        
-        # Handle compound extensions like .tar.gz
-        if '.tar.' in path:
-            return True
-        
-        return False
+        return self._url_filter.is_skippable_extension(url)
     
     def _is_extractable_doc(self, url: str) -> bool:
         """Check if URL is an extractable document (PDF, DOCX, etc.)."""
-        parsed = urlparse(url)
-        path = parsed.path.lower()
-        for ext in EXTRACTABLE_DOC_EXTENSIONS:
-            if path.endswith(ext):
-                return True
-        return False
+        return self._url_filter.is_extractable_doc(url)
     
     def _is_skippable_path(self, url: str) -> bool:
         """Check if URL path indicates non-documentation content."""
-        parsed = urlparse(url)
-        path = parsed.path.lower()
-        
-        for pattern in SKIP_PATH_PATTERNS:
-            if pattern in path:
-                return True
-        
-        return False
+        return self._url_filter.is_skippable_path(url)
     
     def _is_under_base_path(self, url: str) -> bool:
         """Check if URL is under the base path."""
-        if not self.same_path:
-            return True
-        
-        if not self.base_path:
-            return True
-        
-        parsed = urlparse(url)
-        url_path = parsed.path.rstrip('/')
-        
-        # URL must start with base_path
-        # e.g., base_path="/3.11" should match "/3.11", "/3.11/", "/3.11/library/", etc.
-        if url_path == self.base_path:
-            return True
-        if url_path.startswith(self.base_path + '/'):
-            return True
-        
-        return False
+        return self._url_filter.is_under_base_path(url)
     
     def _should_crawl(self, url: str, depth: int = 0, force: bool = False) -> bool:
         """Check if URL should be crawled."""
-        # Already visited (skip in incremental mode with force=True)
-        if not force and self.state.is_visited(url):
-            return False
-        
-        # Depth check
-        if self.max_depth is not None and depth > self.max_depth:
-            return False
-        
-        # Skip non-HTML extensions
-        if self._is_skippable_extension(url):
-            return False
-        
-        # Skip obvious non-doc paths
-        if self._is_skippable_path(url):
-            return False
-        
-        # Domain check
-        if self.stay_on_domain and not is_same_domain(url, self.base_url):
-            return False
-        
-        # Path prefix check (the critical bug fix!)
-        if not self._is_under_base_path(url):
-            return False
-        
-        # Robots.txt check
-        if not self.robots.can_fetch(url):
-            return False
-        
-        # Custom filter
-        if self.url_filter and not self.url_filter(url):
-            return False
-        
-        return True
+        return self._url_filter.should_follow(
+            url,
+            depth=depth,
+            is_visited_func=self.state.is_visited,
+            force=force,
+        )
     
     def _save_page(self, url: str, data: dict):
         """Save page data to disk."""

--- a/doc_search/crawler/url_filter.py
+++ b/doc_search/crawler/url_filter.py
@@ -1,0 +1,290 @@
+"""
+URL filtering logic for the web crawler.
+
+This module handles:
+- URL validation
+- Extension checking (SKIP_EXTENSIONS, EXTRACTABLE_DOC_EXTENSIONS)
+- Path pattern matching (SKIP_PATH_PATTERNS)
+- should_follow logic for crawl decisions
+"""
+
+from typing import Optional, Callable
+from urllib.parse import urlparse
+
+from ..utils import normalize_url, is_same_domain, get_domain
+from ..robots import RobotsChecker
+
+
+# Extensions that should never be crawled (archives, media, binaries)
+SKIP_EXTENSIONS = frozenset([
+    # Archives
+    '.tar', '.gz', '.tgz', '.tar.gz', '.tar.bz2', '.tar.xz',
+    '.zip', '.rar', '.7z', '.bz2', '.xz', '.lz', '.lzma',
+    # Documents (excluded by default, can be enabled with extract_docs=True)
+    '.epub', '.mobi', '.ppt', '.pptx', '.odt', '.ods', '.odp',
+    # Images
+    '.jpg', '.jpeg', '.png', '.gif', '.svg', '.ico', '.webp',
+    '.bmp', '.tiff', '.tif', '.psd', '.ai', '.eps',
+    # Media
+    '.mp3', '.mp4', '.avi', '.mov', '.wmv', '.flv', '.mkv',
+    '.wav', '.ogg', '.webm', '.m4a', '.m4v',
+    # Code/data files (usually not documentation)
+    '.css', '.js', '.json', '.xml', '.rss', '.atom',
+    '.woff', '.woff2', '.ttf', '.eot', '.otf',
+    # Executables and packages
+    '.exe', '.msi', '.dmg', '.pkg', '.deb', '.rpm',
+    '.whl', '.egg', '.jar', '.war', '.apk', '.ipa',
+    # Source archives
+    '.asc', '.sig', '.sha256', '.md5',
+])
+
+# Document extensions that can be extracted (when extract_docs=True)
+EXTRACTABLE_DOC_EXTENSIONS = frozenset([
+    '.pdf',
+    '.doc', '.docx',
+    '.xls', '.xlsx',
+])
+
+# URL path patterns that indicate non-documentation content
+SKIP_PATH_PATTERNS = [
+    '/download/', '/downloads/',
+    '/archive/', '/archives/',
+    '/releases/', '/release/',
+    '/dist/', '/ftp/',
+    '/source/', '/sources/',
+    '/packages/', '/pkg/',
+    '/binaries/', '/bin/',
+]
+
+
+def is_skippable_extension(url: str, extract_docs: bool = False) -> bool:
+    """
+    Check if URL has an extension that should be skipped.
+    
+    Args:
+        url: The URL to check
+        extract_docs: If True, extractable document extensions (PDF, DOCX, etc.)
+                      will NOT be skipped
+    
+    Returns:
+        True if the URL should be skipped based on its extension
+    """
+    parsed = urlparse(url)
+    path = parsed.path.lower()
+    
+    # Check each skip extension
+    for ext in SKIP_EXTENSIONS:
+        if path.endswith(ext):
+            return True
+    
+    # Check extractable document extensions
+    # Skip them unless extract_docs is enabled
+    if not extract_docs:
+        for ext in EXTRACTABLE_DOC_EXTENSIONS:
+            if path.endswith(ext):
+                return True
+    
+    # Handle compound extensions like .tar.gz
+    if '.tar.' in path:
+        return True
+    
+    return False
+
+
+def is_extractable_doc(url: str) -> bool:
+    """
+    Check if URL is an extractable document (PDF, DOCX, etc.).
+    
+    Args:
+        url: The URL to check
+    
+    Returns:
+        True if the URL points to an extractable document
+    """
+    parsed = urlparse(url)
+    path = parsed.path.lower()
+    for ext in EXTRACTABLE_DOC_EXTENSIONS:
+        if path.endswith(ext):
+            return True
+    return False
+
+
+def is_skippable_path(url: str) -> bool:
+    """
+    Check if URL path indicates non-documentation content.
+    
+    Args:
+        url: The URL to check
+    
+    Returns:
+        True if the URL path matches a skip pattern
+    """
+    parsed = urlparse(url)
+    path = parsed.path.lower()
+    
+    for pattern in SKIP_PATH_PATTERNS:
+        if pattern in path:
+            return True
+    
+    return False
+
+
+def is_under_base_path(url: str, base_path: str, same_path: bool = True) -> bool:
+    """
+    Check if URL is under the base path.
+    
+    Args:
+        url: The URL to check
+        base_path: The base path to compare against (e.g., '/3.11')
+        same_path: If False, always returns True (no path restriction)
+    
+    Returns:
+        True if the URL is under the base path
+    """
+    if not same_path:
+        return True
+    
+    if not base_path:
+        return True
+    
+    parsed = urlparse(url)
+    url_path = parsed.path.rstrip('/')
+    
+    # URL must start with base_path
+    # e.g., base_path="/3.11" should match "/3.11", "/3.11/", "/3.11/library/", etc.
+    if url_path == base_path:
+        return True
+    if url_path.startswith(base_path + '/'):
+        return True
+    
+    return False
+
+
+class UrlFilter:
+    """
+    URL filtering logic for the web crawler.
+    
+    Encapsulates all the logic for determining whether a URL should be crawled,
+    including extension checking, path pattern matching, domain restrictions,
+    and robots.txt compliance.
+    """
+    
+    def __init__(
+        self,
+        base_url: str,
+        robots_checker: Optional[RobotsChecker] = None,
+        stay_on_domain: bool = True,
+        same_path: bool = False,
+        extract_docs: bool = False,
+        max_depth: Optional[int] = None,
+        url_filter: Optional[Callable[[str], bool]] = None,
+    ):
+        """
+        Initialize the URL filter.
+        
+        Args:
+            base_url: The starting URL for the crawl
+            robots_checker: RobotsChecker instance for robots.txt compliance
+            stay_on_domain: If True, only crawl URLs on the same domain
+            same_path: If True, only crawl URLs under the starting path
+            extract_docs: If True, allow extractable document extensions
+            max_depth: Maximum crawl depth (None for unlimited)
+            url_filter: Optional custom filter function
+        """
+        self.base_url = normalize_url(base_url)
+        self.base_domain = get_domain(base_url)
+        self.robots_checker = robots_checker
+        self.stay_on_domain = stay_on_domain
+        self.same_path = same_path
+        self.extract_docs = extract_docs
+        self.max_depth = max_depth
+        self.custom_filter = url_filter
+        
+        # Extract base path for same_path filtering
+        parsed = urlparse(self.base_url)
+        self.base_path = parsed.path.rstrip('/') or ''
+        # For root paths (empty or /), allow everything under domain
+        if self.base_path == '' or self.base_path == '/':
+            self.base_path = ''
+            self.same_path = False  # No path restriction for root
+    
+    def is_skippable_extension(self, url: str) -> bool:
+        """Check if URL has an extension that should be skipped."""
+        return is_skippable_extension(url, self.extract_docs)
+    
+    def is_extractable_doc(self, url: str) -> bool:
+        """Check if URL is an extractable document (PDF, DOCX, etc.)."""
+        return is_extractable_doc(url)
+    
+    def is_skippable_path(self, url: str) -> bool:
+        """Check if URL path indicates non-documentation content."""
+        return is_skippable_path(url)
+    
+    def is_under_base_path(self, url: str) -> bool:
+        """Check if URL is under the base path."""
+        return is_under_base_path(url, self.base_path, self.same_path)
+    
+    def should_follow(
+        self,
+        url: str,
+        depth: int = 0,
+        is_visited_func: Optional[Callable[[str], bool]] = None,
+        force: bool = False,
+    ) -> bool:
+        """
+        Check if URL should be crawled.
+        
+        Args:
+            url: The URL to check
+            depth: Current crawl depth
+            is_visited_func: Optional function to check if URL was already visited
+            force: If True, skip the visited check (for incremental crawling)
+        
+        Returns:
+            True if the URL should be crawled
+        """
+        # Already visited (skip in incremental mode with force=True)
+        if not force and is_visited_func and is_visited_func(url):
+            return False
+        
+        # Depth check
+        if self.max_depth is not None and depth > self.max_depth:
+            return False
+        
+        # Skip non-HTML extensions
+        if self.is_skippable_extension(url):
+            return False
+        
+        # Skip obvious non-doc paths
+        if self.is_skippable_path(url):
+            return False
+        
+        # Domain check
+        if self.stay_on_domain and not is_same_domain(url, self.base_url):
+            return False
+        
+        # Path prefix check
+        if not self.is_under_base_path(url):
+            return False
+        
+        # Robots.txt check
+        if self.robots_checker and not self.robots_checker.can_fetch(url):
+            return False
+        
+        # Custom filter
+        if self.custom_filter and not self.custom_filter(url):
+            return False
+        
+        return True
+
+
+__all__ = [
+    'SKIP_EXTENSIONS',
+    'EXTRACTABLE_DOC_EXTENSIONS',
+    'SKIP_PATH_PATTERNS',
+    'is_skippable_extension',
+    'is_extractable_doc',
+    'is_skippable_path',
+    'is_under_base_path',
+    'UrlFilter',
+]

--- a/tests/test_url_filter.py
+++ b/tests/test_url_filter.py
@@ -1,0 +1,707 @@
+"""
+Tests for the URL filtering module.
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from doc_search.crawler.url_filter import (
+    SKIP_EXTENSIONS,
+    EXTRACTABLE_DOC_EXTENSIONS,
+    SKIP_PATH_PATTERNS,
+    is_skippable_extension,
+    is_extractable_doc,
+    is_skippable_path,
+    is_under_base_path,
+    UrlFilter,
+)
+
+
+# ============================================================================
+# Test Constants
+# ============================================================================
+
+class TestConstants(unittest.TestCase):
+    """Test the module-level constants."""
+    
+    def test_skip_extensions_is_frozenset(self):
+        """SKIP_EXTENSIONS should be a frozenset for immutability."""
+        self.assertIsInstance(SKIP_EXTENSIONS, frozenset)
+    
+    def test_skip_extensions_contains_common_binaries(self):
+        """SKIP_EXTENSIONS should contain common binary extensions."""
+        # Archives
+        self.assertIn('.zip', SKIP_EXTENSIONS)
+        self.assertIn('.tar', SKIP_EXTENSIONS)
+        self.assertIn('.gz', SKIP_EXTENSIONS)
+        self.assertIn('.rar', SKIP_EXTENSIONS)
+        self.assertIn('.7z', SKIP_EXTENSIONS)
+        
+        # Images
+        self.assertIn('.jpg', SKIP_EXTENSIONS)
+        self.assertIn('.png', SKIP_EXTENSIONS)
+        self.assertIn('.gif', SKIP_EXTENSIONS)
+        self.assertIn('.svg', SKIP_EXTENSIONS)
+        
+        # Media
+        self.assertIn('.mp3', SKIP_EXTENSIONS)
+        self.assertIn('.mp4', SKIP_EXTENSIONS)
+        self.assertIn('.avi', SKIP_EXTENSIONS)
+        
+        # Executables
+        self.assertIn('.exe', SKIP_EXTENSIONS)
+        self.assertIn('.dmg', SKIP_EXTENSIONS)
+        self.assertIn('.deb', SKIP_EXTENSIONS)
+        
+        # Code/data files
+        self.assertIn('.css', SKIP_EXTENSIONS)
+        self.assertIn('.js', SKIP_EXTENSIONS)
+        self.assertIn('.json', SKIP_EXTENSIONS)
+    
+    def test_extractable_doc_extensions_is_frozenset(self):
+        """EXTRACTABLE_DOC_EXTENSIONS should be a frozenset."""
+        self.assertIsInstance(EXTRACTABLE_DOC_EXTENSIONS, frozenset)
+    
+    def test_extractable_doc_extensions_contains_documents(self):
+        """EXTRACTABLE_DOC_EXTENSIONS should contain document extensions."""
+        self.assertIn('.pdf', EXTRACTABLE_DOC_EXTENSIONS)
+        self.assertIn('.doc', EXTRACTABLE_DOC_EXTENSIONS)
+        self.assertIn('.docx', EXTRACTABLE_DOC_EXTENSIONS)
+        self.assertIn('.xls', EXTRACTABLE_DOC_EXTENSIONS)
+        self.assertIn('.xlsx', EXTRACTABLE_DOC_EXTENSIONS)
+    
+    def test_skip_path_patterns_is_list(self):
+        """SKIP_PATH_PATTERNS should be a list."""
+        self.assertIsInstance(SKIP_PATH_PATTERNS, list)
+    
+    def test_skip_path_patterns_contains_common_patterns(self):
+        """SKIP_PATH_PATTERNS should contain common non-doc patterns."""
+        self.assertIn('/download/', SKIP_PATH_PATTERNS)
+        self.assertIn('/downloads/', SKIP_PATH_PATTERNS)
+        self.assertIn('/archive/', SKIP_PATH_PATTERNS)
+        self.assertIn('/releases/', SKIP_PATH_PATTERNS)
+        self.assertIn('/dist/', SKIP_PATH_PATTERNS)
+
+
+# ============================================================================
+# Test Standalone Functions
+# ============================================================================
+
+class TestIsSkippableExtension(unittest.TestCase):
+    """Tests for the is_skippable_extension function."""
+    
+    def test_skippable_archive_extensions(self):
+        """Archive extensions should be skipped."""
+        self.assertTrue(is_skippable_extension('https://example.com/file.zip'))
+        self.assertTrue(is_skippable_extension('https://example.com/file.tar'))
+        self.assertTrue(is_skippable_extension('https://example.com/file.gz'))
+        self.assertTrue(is_skippable_extension('https://example.com/file.tar.gz'))
+        self.assertTrue(is_skippable_extension('https://example.com/file.tar.bz2'))
+        self.assertTrue(is_skippable_extension('https://example.com/file.7z'))
+    
+    def test_skippable_image_extensions(self):
+        """Image extensions should be skipped."""
+        self.assertTrue(is_skippable_extension('https://example.com/image.jpg'))
+        self.assertTrue(is_skippable_extension('https://example.com/image.jpeg'))
+        self.assertTrue(is_skippable_extension('https://example.com/image.png'))
+        self.assertTrue(is_skippable_extension('https://example.com/image.gif'))
+        self.assertTrue(is_skippable_extension('https://example.com/image.svg'))
+        self.assertTrue(is_skippable_extension('https://example.com/icon.ico'))
+    
+    def test_skippable_media_extensions(self):
+        """Media extensions should be skipped."""
+        self.assertTrue(is_skippable_extension('https://example.com/video.mp4'))
+        self.assertTrue(is_skippable_extension('https://example.com/audio.mp3'))
+        self.assertTrue(is_skippable_extension('https://example.com/video.avi'))
+        self.assertTrue(is_skippable_extension('https://example.com/video.mkv'))
+    
+    def test_skippable_code_data_extensions(self):
+        """Code and data file extensions should be skipped."""
+        self.assertTrue(is_skippable_extension('https://example.com/style.css'))
+        self.assertTrue(is_skippable_extension('https://example.com/script.js'))
+        self.assertTrue(is_skippable_extension('https://example.com/data.json'))
+        self.assertTrue(is_skippable_extension('https://example.com/font.woff2'))
+    
+    def test_compound_extensions_tar_gz(self):
+        """Compound extensions like .tar.gz should be skipped."""
+        self.assertTrue(is_skippable_extension('https://example.com/archive.tar.gz'))
+        self.assertTrue(is_skippable_extension('https://example.com/file.tar.bz2'))
+        self.assertTrue(is_skippable_extension('https://example.com/file.tar.xz'))
+    
+    def test_html_not_skipped(self):
+        """HTML extensions should not be skipped."""
+        self.assertFalse(is_skippable_extension('https://example.com/page.html'))
+        self.assertFalse(is_skippable_extension('https://example.com/page.htm'))
+    
+    def test_no_extension_not_skipped(self):
+        """URLs without extensions should not be skipped."""
+        self.assertFalse(is_skippable_extension('https://example.com/page'))
+        self.assertFalse(is_skippable_extension('https://example.com/docs/'))
+        self.assertFalse(is_skippable_extension('https://example.com/'))
+    
+    def test_case_insensitive(self):
+        """Extension checking should be case-insensitive."""
+        self.assertTrue(is_skippable_extension('https://example.com/file.ZIP'))
+        self.assertTrue(is_skippable_extension('https://example.com/image.PNG'))
+        self.assertTrue(is_skippable_extension('https://example.com/IMAGE.JPG'))
+    
+    def test_pdf_skipped_without_extract_docs(self):
+        """PDF should be skipped when extract_docs=False."""
+        self.assertTrue(is_skippable_extension('https://example.com/doc.pdf'))
+        self.assertTrue(is_skippable_extension('https://example.com/file.docx'))
+        self.assertTrue(is_skippable_extension('https://example.com/data.xlsx'))
+    
+    def test_pdf_not_skipped_with_extract_docs(self):
+        """PDF should not be skipped when extract_docs=True."""
+        self.assertFalse(is_skippable_extension('https://example.com/doc.pdf', extract_docs=True))
+        self.assertFalse(is_skippable_extension('https://example.com/file.docx', extract_docs=True))
+        self.assertFalse(is_skippable_extension('https://example.com/data.xlsx', extract_docs=True))
+
+
+class TestIsExtractableDoc(unittest.TestCase):
+    """Tests for the is_extractable_doc function."""
+    
+    def test_pdf_is_extractable(self):
+        """PDF files should be extractable."""
+        self.assertTrue(is_extractable_doc('https://example.com/document.pdf'))
+        self.assertTrue(is_extractable_doc('https://example.com/path/to/file.pdf'))
+    
+    def test_office_docs_are_extractable(self):
+        """Office document files should be extractable."""
+        self.assertTrue(is_extractable_doc('https://example.com/doc.doc'))
+        self.assertTrue(is_extractable_doc('https://example.com/doc.docx'))
+        self.assertTrue(is_extractable_doc('https://example.com/spreadsheet.xls'))
+        self.assertTrue(is_extractable_doc('https://example.com/spreadsheet.xlsx'))
+    
+    def test_html_not_extractable(self):
+        """HTML files should not be considered extractable docs."""
+        self.assertFalse(is_extractable_doc('https://example.com/page.html'))
+    
+    def test_zip_not_extractable(self):
+        """Archives should not be considered extractable docs."""
+        self.assertFalse(is_extractable_doc('https://example.com/file.zip'))
+    
+    def test_no_extension_not_extractable(self):
+        """URLs without extensions should not be extractable."""
+        self.assertFalse(is_extractable_doc('https://example.com/page'))
+    
+    def test_case_insensitive(self):
+        """Extension checking should be case-insensitive."""
+        self.assertTrue(is_extractable_doc('https://example.com/doc.PDF'))
+        self.assertTrue(is_extractable_doc('https://example.com/doc.DOCX'))
+
+
+class TestIsSkippablePath(unittest.TestCase):
+    """Tests for the is_skippable_path function."""
+    
+    def test_download_paths_skipped(self):
+        """Download paths should be skipped."""
+        self.assertTrue(is_skippable_path('https://example.com/download/file'))
+        self.assertTrue(is_skippable_path('https://example.com/downloads/file'))
+    
+    def test_archive_paths_skipped(self):
+        """Archive paths should be skipped."""
+        self.assertTrue(is_skippable_path('https://example.com/archive/2023'))
+        self.assertTrue(is_skippable_path('https://example.com/archives/old'))
+    
+    def test_release_paths_skipped(self):
+        """Release paths should be skipped."""
+        self.assertTrue(is_skippable_path('https://example.com/releases/v1.0'))
+        self.assertTrue(is_skippable_path('https://example.com/release/latest'))
+    
+    def test_dist_paths_skipped(self):
+        """Distribution paths should be skipped."""
+        self.assertTrue(is_skippable_path('https://example.com/dist/package'))
+        self.assertTrue(is_skippable_path('https://example.com/ftp/files'))
+    
+    def test_source_paths_skipped(self):
+        """Source paths should be skipped."""
+        self.assertTrue(is_skippable_path('https://example.com/source/code'))
+        self.assertTrue(is_skippable_path('https://example.com/sources/lib'))
+    
+    def test_package_paths_skipped(self):
+        """Package paths should be skipped."""
+        self.assertTrue(is_skippable_path('https://example.com/packages/npm'))
+        self.assertTrue(is_skippable_path('https://example.com/pkg/latest'))
+    
+    def test_binary_paths_skipped(self):
+        """Binary paths should be skipped."""
+        self.assertTrue(is_skippable_path('https://example.com/binaries/x64'))
+        self.assertTrue(is_skippable_path('https://example.com/bin/exec'))
+    
+    def test_docs_paths_not_skipped(self):
+        """Documentation paths should not be skipped."""
+        self.assertFalse(is_skippable_path('https://example.com/docs/guide'))
+        self.assertFalse(is_skippable_path('https://example.com/documentation/api'))
+    
+    def test_api_paths_not_skipped(self):
+        """API documentation paths should not be skipped."""
+        self.assertFalse(is_skippable_path('https://example.com/api/reference'))
+    
+    def test_root_path_not_skipped(self):
+        """Root path should not be skipped."""
+        self.assertFalse(is_skippable_path('https://example.com/'))
+    
+    def test_case_insensitive(self):
+        """Path checking should be case-insensitive."""
+        self.assertTrue(is_skippable_path('https://example.com/DOWNLOAD/file'))
+        self.assertTrue(is_skippable_path('https://example.com/Downloads/file'))
+
+
+class TestIsUnderBasePath(unittest.TestCase):
+    """Tests for the is_under_base_path function."""
+    
+    def test_exact_match(self):
+        """URL path that exactly matches base_path should be under it."""
+        self.assertTrue(is_under_base_path(
+            'https://example.com/docs',
+            '/docs',
+            same_path=True
+        ))
+    
+    def test_subpath_match(self):
+        """URL path under base_path should be under it."""
+        self.assertTrue(is_under_base_path(
+            'https://example.com/docs/guide',
+            '/docs',
+            same_path=True
+        ))
+        self.assertTrue(is_under_base_path(
+            'https://example.com/docs/api/reference',
+            '/docs',
+            same_path=True
+        ))
+    
+    def test_different_path_not_under(self):
+        """URL path not under base_path should not be under it."""
+        self.assertFalse(is_under_base_path(
+            'https://example.com/other',
+            '/docs',
+            same_path=True
+        ))
+        self.assertFalse(is_under_base_path(
+            'https://example.com/documentation',
+            '/docs',
+            same_path=True
+        ))
+    
+    def test_sibling_path_not_under(self):
+        """Sibling paths should not be considered under base_path."""
+        # /docs-extra is NOT under /docs
+        self.assertFalse(is_under_base_path(
+            'https://example.com/docs-extra',
+            '/docs',
+            same_path=True
+        ))
+    
+    def test_same_path_false_returns_true(self):
+        """When same_path=False, should always return True."""
+        self.assertTrue(is_under_base_path(
+            'https://example.com/other',
+            '/docs',
+            same_path=False
+        ))
+    
+    def test_empty_base_path_returns_true(self):
+        """Empty base_path should always return True."""
+        self.assertTrue(is_under_base_path(
+            'https://example.com/anything',
+            '',
+            same_path=True
+        ))
+    
+    def test_trailing_slash_handling(self):
+        """Should handle trailing slashes correctly."""
+        # URL with trailing slash
+        self.assertTrue(is_under_base_path(
+            'https://example.com/docs/',
+            '/docs',
+            same_path=True
+        ))
+        # Deeply nested with trailing slash
+        self.assertTrue(is_under_base_path(
+            'https://example.com/docs/guide/',
+            '/docs',
+            same_path=True
+        ))
+    
+    def test_version_paths(self):
+        """Should work with version paths like /3.11."""
+        self.assertTrue(is_under_base_path(
+            'https://docs.python.org/3.11',
+            '/3.11',
+            same_path=True
+        ))
+        self.assertTrue(is_under_base_path(
+            'https://docs.python.org/3.11/library/os.html',
+            '/3.11',
+            same_path=True
+        ))
+        # Should not match /3.11x or /3.111
+        self.assertFalse(is_under_base_path(
+            'https://docs.python.org/3.111',
+            '/3.11',
+            same_path=True
+        ))
+
+
+# ============================================================================
+# Test UrlFilter Class
+# ============================================================================
+
+class TestUrlFilterInit(unittest.TestCase):
+    """Tests for UrlFilter initialization."""
+    
+    def test_basic_init(self):
+        """Test basic initialization."""
+        url_filter = UrlFilter('https://example.com/docs/')
+        
+        self.assertEqual(url_filter.base_url, 'https://example.com/docs/')
+        self.assertEqual(url_filter.base_domain, 'example.com')
+        self.assertEqual(url_filter.base_path, '/docs')
+        self.assertTrue(url_filter.stay_on_domain)
+        self.assertFalse(url_filter.same_path)  # default
+        self.assertFalse(url_filter.extract_docs)
+        self.assertIsNone(url_filter.max_depth)
+        self.assertIsNone(url_filter.custom_filter)
+    
+    def test_init_with_same_path(self):
+        """Test initialization with same_path=True."""
+        url_filter = UrlFilter('https://example.com/docs/', same_path=True)
+        
+        self.assertTrue(url_filter.same_path)
+        self.assertEqual(url_filter.base_path, '/docs')
+    
+    def test_root_path_disables_same_path(self):
+        """Root paths should disable same_path restriction."""
+        url_filter = UrlFilter('https://example.com/', same_path=True)
+        
+        # same_path should be disabled for root
+        self.assertFalse(url_filter.same_path)
+        self.assertEqual(url_filter.base_path, '')
+    
+    def test_init_with_robots_checker(self):
+        """Test initialization with robots checker."""
+        mock_robots = Mock()
+        url_filter = UrlFilter('https://example.com/', robots_checker=mock_robots)
+        
+        self.assertEqual(url_filter.robots_checker, mock_robots)
+    
+    def test_init_with_custom_filter(self):
+        """Test initialization with custom filter function."""
+        custom_fn = lambda url: 'allowed' in url
+        url_filter = UrlFilter('https://example.com/', url_filter=custom_fn)
+        
+        self.assertEqual(url_filter.custom_filter, custom_fn)
+
+
+class TestUrlFilterMethods(unittest.TestCase):
+    """Tests for UrlFilter instance methods."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.url_filter = UrlFilter(
+            'https://example.com/docs/',
+            same_path=True,
+            extract_docs=False,
+        )
+    
+    def test_is_skippable_extension_delegates(self):
+        """is_skippable_extension should delegate to module function."""
+        self.assertTrue(self.url_filter.is_skippable_extension('https://example.com/file.zip'))
+        self.assertFalse(self.url_filter.is_skippable_extension('https://example.com/page.html'))
+    
+    def test_is_skippable_extension_respects_extract_docs(self):
+        """is_skippable_extension should respect extract_docs setting."""
+        # Default (extract_docs=False) - PDF is skipped
+        self.assertTrue(self.url_filter.is_skippable_extension('https://example.com/doc.pdf'))
+        
+        # With extract_docs=True - PDF is not skipped
+        url_filter_docs = UrlFilter('https://example.com/', extract_docs=True)
+        self.assertFalse(url_filter_docs.is_skippable_extension('https://example.com/doc.pdf'))
+    
+    def test_is_extractable_doc_delegates(self):
+        """is_extractable_doc should delegate to module function."""
+        self.assertTrue(self.url_filter.is_extractable_doc('https://example.com/doc.pdf'))
+        self.assertFalse(self.url_filter.is_extractable_doc('https://example.com/page.html'))
+    
+    def test_is_skippable_path_delegates(self):
+        """is_skippable_path should delegate to module function."""
+        self.assertTrue(self.url_filter.is_skippable_path('https://example.com/download/file'))
+        self.assertFalse(self.url_filter.is_skippable_path('https://example.com/docs/guide'))
+    
+    def test_is_under_base_path_delegates(self):
+        """is_under_base_path should delegate to module function."""
+        self.assertTrue(self.url_filter.is_under_base_path('https://example.com/docs/guide'))
+        self.assertFalse(self.url_filter.is_under_base_path('https://example.com/other'))
+
+
+class TestUrlFilterShouldFollow(unittest.TestCase):
+    """Tests for UrlFilter.should_follow method."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_robots = Mock()
+        self.mock_robots.can_fetch.return_value = True
+        
+        self.url_filter = UrlFilter(
+            'https://example.com/docs/',
+            robots_checker=self.mock_robots,
+            stay_on_domain=True,
+            same_path=True,
+            extract_docs=False,
+            max_depth=3,
+        )
+    
+    def test_should_follow_valid_url(self):
+        """Valid URL should be followed."""
+        self.assertTrue(self.url_filter.should_follow(
+            'https://example.com/docs/guide',
+            depth=1
+        ))
+    
+    def test_should_not_follow_visited_url(self):
+        """Already visited URL should not be followed."""
+        is_visited = lambda url: url == 'https://example.com/docs/visited'
+        
+        self.assertFalse(self.url_filter.should_follow(
+            'https://example.com/docs/visited',
+            depth=1,
+            is_visited_func=is_visited
+        ))
+    
+    def test_should_follow_visited_url_with_force(self):
+        """Visited URL should be followed when force=True."""
+        is_visited = lambda url: url == 'https://example.com/docs/visited'
+        
+        self.assertTrue(self.url_filter.should_follow(
+            'https://example.com/docs/visited',
+            depth=1,
+            is_visited_func=is_visited,
+            force=True
+        ))
+    
+    def test_should_not_follow_beyond_max_depth(self):
+        """URL beyond max_depth should not be followed."""
+        self.assertFalse(self.url_filter.should_follow(
+            'https://example.com/docs/guide',
+            depth=4  # max_depth=3
+        ))
+    
+    def test_should_not_follow_skippable_extension(self):
+        """URL with skippable extension should not be followed."""
+        self.assertFalse(self.url_filter.should_follow(
+            'https://example.com/docs/image.png',
+            depth=1
+        ))
+    
+    def test_should_not_follow_skippable_path(self):
+        """URL with skippable path should not be followed."""
+        self.assertFalse(self.url_filter.should_follow(
+            'https://example.com/docs/download/file',
+            depth=1
+        ))
+    
+    def test_should_not_follow_different_domain(self):
+        """URL on different domain should not be followed."""
+        self.assertFalse(self.url_filter.should_follow(
+            'https://other.com/docs/guide',
+            depth=1
+        ))
+    
+    def test_should_not_follow_outside_base_path(self):
+        """URL outside base_path should not be followed."""
+        self.assertFalse(self.url_filter.should_follow(
+            'https://example.com/other/page',
+            depth=1
+        ))
+    
+    def test_should_not_follow_robots_disallowed(self):
+        """URL disallowed by robots.txt should not be followed."""
+        self.mock_robots.can_fetch.return_value = False
+        
+        self.assertFalse(self.url_filter.should_follow(
+            'https://example.com/docs/private',
+            depth=1
+        ))
+    
+    def test_should_not_follow_custom_filter_reject(self):
+        """URL rejected by custom filter should not be followed."""
+        url_filter = UrlFilter(
+            'https://example.com/',
+            url_filter=lambda url: 'allowed' in url
+        )
+        
+        self.assertFalse(url_filter.should_follow(
+            'https://example.com/rejected',
+            depth=1
+        ))
+        self.assertTrue(url_filter.should_follow(
+            'https://example.com/allowed-page',
+            depth=1
+        ))
+    
+    def test_should_follow_without_robots_checker(self):
+        """URL should be followed even without robots checker."""
+        url_filter = UrlFilter('https://example.com/', robots_checker=None)
+        
+        self.assertTrue(url_filter.should_follow(
+            'https://example.com/page',
+            depth=1
+        ))
+    
+    def test_should_follow_without_is_visited_func(self):
+        """URL should be followed without is_visited_func."""
+        self.assertTrue(self.url_filter.should_follow(
+            'https://example.com/docs/guide',
+            depth=1,
+            is_visited_func=None
+        ))
+    
+    def test_should_follow_no_max_depth(self):
+        """URL at any depth should be followed when max_depth is None."""
+        url_filter = UrlFilter('https://example.com/', max_depth=None)
+        
+        self.assertTrue(url_filter.should_follow(
+            'https://example.com/deep/nested/path',
+            depth=100
+        ))
+    
+    def test_cross_domain_allowed_when_stay_on_domain_false(self):
+        """Cross-domain URLs should be followed when stay_on_domain=False."""
+        url_filter = UrlFilter('https://example.com/', stay_on_domain=False)
+        
+        self.assertTrue(url_filter.should_follow(
+            'https://other-domain.com/page',
+            depth=1
+        ))
+
+
+class TestUrlFilterEdgeCases(unittest.TestCase):
+    """Tests for edge cases in UrlFilter."""
+    
+    def test_url_with_query_params(self):
+        """URLs with query parameters should be handled correctly."""
+        url_filter = UrlFilter('https://example.com/docs/')
+        
+        self.assertTrue(url_filter.should_follow(
+            'https://example.com/docs/page?param=value',
+            depth=1
+        ))
+    
+    def test_url_with_fragment(self):
+        """URLs with fragments should be handled correctly."""
+        url_filter = UrlFilter('https://example.com/docs/')
+        
+        self.assertTrue(url_filter.should_follow(
+            'https://example.com/docs/page#section',
+            depth=1
+        ))
+    
+    def test_url_with_port(self):
+        """URLs with ports should be handled correctly."""
+        url_filter = UrlFilter('https://example.com:8080/docs/')
+        
+        self.assertTrue(url_filter.should_follow(
+            'https://example.com:8080/docs/page',
+            depth=1
+        ))
+    
+    def test_url_with_username_password(self):
+        """URLs with credentials may fail domain matching."""
+        url_filter = UrlFilter('https://example.com/docs/')
+        
+        # URLs with credentials may not match same_domain check
+        # This is actually expected behavior - the netloc includes credentials
+        # so 'user:pass@example.com' != 'example.com'
+        # This test documents the current behavior
+        result = url_filter.should_follow(
+            'https://user:pass@example.com/docs/page',
+            depth=1
+        )
+        # The URL fails domain check because netloc includes credentials
+        self.assertFalse(result)
+    
+    def test_empty_url(self):
+        """Empty URL should be handled gracefully."""
+        url_filter = UrlFilter('https://example.com/')
+        
+        # Empty URL has no domain, so it shouldn't match
+        self.assertFalse(url_filter.should_follow('', depth=1))
+    
+    def test_relative_url_handling(self):
+        """Relative URLs should be handled (though typically resolved before filtering)."""
+        url_filter = UrlFilter('https://example.com/')
+        
+        # Relative URLs without domain won't match same_domain check
+        self.assertFalse(url_filter.should_follow('/relative/path', depth=1))
+    
+    def test_extract_docs_pdf_allowed(self):
+        """PDF should be allowed when extract_docs=True."""
+        url_filter = UrlFilter('https://example.com/', extract_docs=True)
+        
+        self.assertTrue(url_filter.should_follow(
+            'https://example.com/document.pdf',
+            depth=1
+        ))
+    
+    def test_always_skip_images_even_with_extract_docs(self):
+        """Images should always be skipped even with extract_docs=True."""
+        url_filter = UrlFilter('https://example.com/', extract_docs=True)
+        
+        self.assertFalse(url_filter.should_follow(
+            'https://example.com/image.png',
+            depth=1
+        ))
+
+
+# ============================================================================
+# Test Module Exports
+# ============================================================================
+
+class TestModuleExports(unittest.TestCase):
+    """Tests for module exports."""
+    
+    def test_can_import_from_url_filter(self):
+        """All public items should be importable from url_filter."""
+        from doc_search.crawler.url_filter import (
+            SKIP_EXTENSIONS,
+            EXTRACTABLE_DOC_EXTENSIONS,
+            SKIP_PATH_PATTERNS,
+            is_skippable_extension,
+            is_extractable_doc,
+            is_skippable_path,
+            is_under_base_path,
+            UrlFilter,
+        )
+        
+        # Just verify they exist
+        self.assertIsNotNone(SKIP_EXTENSIONS)
+        self.assertIsNotNone(EXTRACTABLE_DOC_EXTENSIONS)
+        self.assertIsNotNone(SKIP_PATH_PATTERNS)
+        self.assertIsNotNone(is_skippable_extension)
+        self.assertIsNotNone(is_extractable_doc)
+        self.assertIsNotNone(is_skippable_path)
+        self.assertIsNotNone(is_under_base_path)
+        self.assertIsNotNone(UrlFilter)
+    
+    def test_can_import_from_crawler_package(self):
+        """All public items should be importable from crawler package."""
+        from doc_search.crawler import (
+            SKIP_EXTENSIONS,
+            EXTRACTABLE_DOC_EXTENSIONS,
+            SKIP_PATH_PATTERNS,
+            UrlFilter,
+            is_skippable_extension,
+            is_extractable_doc,
+            is_skippable_path,
+            is_under_base_path,
+        )
+        
+        # Just verify they exist
+        self.assertIsNotNone(SKIP_EXTENSIONS)
+        self.assertIsNotNone(UrlFilter)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Phase 6.2 of crawler modularization - extract URL filtering logic into a dedicated module.

## Changes

### New Module: `doc_search/crawler/url_filter.py`
- **Constants**: `SKIP_EXTENSIONS`, `EXTRACTABLE_DOC_EXTENSIONS`, `SKIP_PATH_PATTERNS`
- **Standalone functions**:
  - `is_skippable_extension(url, extract_docs)` - check for non-doc extensions
  - `is_extractable_doc(url)` - check for PDF/DOCX etc.
  - `is_skippable_path(url)` - check for download/release paths
  - `is_under_base_path(url, base_path, same_path)` - check path prefix matching
- **UrlFilter class**: encapsulates all filtering logic with `should_follow()` method

### Updated `_crawler.py`
- Import from `url_filter` module instead of defining constants locally
- Initialize `UrlFilter` in `Crawler.__init__`
- Delegate filter methods to `UrlFilter` instance:
  - `_is_skippable_extension` → `UrlFilter.is_skippable_extension`
  - `_is_extractable_doc` → `UrlFilter.is_extractable_doc`
  - `_is_skippable_path` → `UrlFilter.is_skippable_path`
  - `_is_under_base_path` → `UrlFilter.is_under_base_path`
  - `_should_crawl` → `UrlFilter.should_follow`

### Updated `__init__.py`
- Re-export constants and functions from `url_filter` instead of `_crawler`
- Add `UrlFilter` class and standalone functions to public API

### New Tests: `tests/test_url_filter.py` (75 tests)
- TestConstants: verify module constants are correct types and contents
- TestIsSkippableExtension: archive, image, media, code extensions
- TestIsExtractableDoc: PDF, Office document detection
- TestIsSkippablePath: download, archive, release paths
- TestIsUnderBasePath: path prefix matching
- TestUrlFilter*: class initialization, methods, should_follow logic
- TestModuleExports: verify public API

## Testing
All **909 tests pass** ✅

## Related
Part of crawler modularization effort (Phase 6).

Closes #96