### PR TITLE
Phase 6.3: Extract crawler/processor.py module

### DIFF
--- a/doc_search/crawler/__init__.py
+++ b/doc_search/crawler/__init__.py
@@ -16,6 +16,12 @@ from .url_filter import (
     is_skippable_path,
     is_under_base_path,
 )
+from .processor import (
+    PageProcessor,
+    content_hash,
+    build_page_data,
+    build_document_data,
+)
 from ..rate_limiter import RateLimiter
 
 __all__ = [
@@ -24,6 +30,7 @@ __all__ = [
     'FetchResult',
     'RateLimiter',
     'UrlFilter',
+    'PageProcessor',
     'SKIP_EXTENSIONS',
     'EXTRACTABLE_DOC_EXTENSIONS',
     'SKIP_PATH_PATTERNS',
@@ -31,4 +38,7 @@ __all__ = [
     'is_extractable_doc',
     'is_skippable_path',
     'is_under_base_path',
+    'content_hash',
+    'build_page_data',
+    'build_document_data',
 ]

--- a/doc_search/crawler/_crawler.py
+++ b/doc_search/crawler/_crawler.py
@@ -5,7 +5,6 @@ Supports parallel crawling with per-domain rate limiting.
 
 import json
 import time
-import hashlib
 import threading
 from pathlib import Path
 from typing import Optional, Set, Dict, Any, Callable, Tuple, List
@@ -18,7 +17,6 @@ from ..utils import (
     create_permissive_ssl_context
 )
 from ..robots import RobotsChecker
-from ..parser import extract_text, extract_links
 from ..constants import (
     DEFAULT_CRAWL_DELAY, DEFAULT_REQUEST_TIMEOUT, MAX_CRAWL_RETRIES,
     CHECKPOINT_INTERVAL as CHECKPOINT_INTERVAL_CONST
@@ -32,6 +30,7 @@ from .url_filter import (
     SKIP_PATH_PATTERNS,
     UrlFilter,
 )
+from .processor import PageProcessor, build_document_data
 
 
 class Crawler:
@@ -146,6 +145,9 @@ class Crawler:
         # Sync base_path and same_path from UrlFilter (it may adjust for root paths)
         self.base_path = self._url_filter.base_path
         self.same_path = self._url_filter.same_path
+        
+        # Initialize page processor
+        self._processor = PageProcessor(self.pages_dir)
     
     def _log(self, message: str):
         """Print message if verbose mode is enabled (thread-safe)."""
@@ -163,21 +165,7 @@ class Crawler:
     
     def _get_page_metadata(self, url: str) -> Optional[Dict[str, Any]]:
         """Load existing page metadata for incremental crawling."""
-        filename = url_to_filename(url) + '.json'
-        filepath = self.pages_dir / filename
-        
-        if not filepath.exists():
-            return None
-        
-        try:
-            with open(filepath, 'r') as f:
-                return json.load(f)
-        except (json.JSONDecodeError, IOError):
-            return None
-    
-    def _content_hash(self, content: str) -> str:
-        """Generate SHA256 hash of content."""
-        return hashlib.sha256(content.encode('utf-8')).hexdigest()
+        return self._processor.load_page_metadata(url)
     
     def _fetch(self, url: str, etag: Optional[str] = None, 
                last_modified: Optional[str] = None) -> Tuple[Optional[str], Optional[str], Dict[str, Any]]:
@@ -218,11 +206,7 @@ class Crawler:
     
     def _save_page(self, url: str, data: dict):
         """Save page data to disk."""
-        filename = url_to_filename(url) + '.json'
-        filepath = self.pages_dir / filename
-        
-        with open(filepath, 'w') as f:
-            json.dump(data, f)
+        self._processor.save_page(url, data)
     
     def _process_page(self, url: str, depth: int) -> Optional[List[Tuple[str, int]]]:
         """
@@ -280,44 +264,30 @@ class Crawler:
             return []
         
         # For incremental: check content hash to detect changes even without 304
-        content_hash = self._content_hash(content)
         if self.incremental and existing_meta:
-            if existing_meta.get('content_hash') == content_hash:
+            changed, _ = self._processor.is_content_changed(content, existing_meta)
+            if not changed:
                 self._log(f"  ⏭️  Unchanged (same hash): {url}")
                 self.state.increment_stat('pages_unchanged')
                 return []
         
-        # Extract content
-        extracted = extract_text(content)
+        # Process HTML: extract text, links, and build page data
+        result = self._processor.process_html(
+            url=url,
+            html=content,
+            depth=depth,
+            etag=fetch_meta.get('etag'),
+            last_modified=fetch_meta.get('last_modified'),
+            link_filter=self._should_crawl,
+        )
         
-        # Extract and queue links (at depth + 1)
-        links = extract_links(content, url)
-        new_depth = depth + 1
-        new_urls = []
-        for link in links:
-            if self._should_crawl(link, new_depth):
-                new_urls.append((link, new_depth))
-        
-        # Save page data with incremental metadata
-        page_data = {
-            'url': url,
-            'title': extracted['title'],
-            'description': extracted['description'],
-            'text': extracted['text'],
-            'headings': extracted['headings'],
-            'depth': depth,
-            'crawled_at': time.time(),
-            # Incremental crawling metadata
-            'etag': fetch_meta.get('etag'),
-            'last_modified': fetch_meta.get('last_modified'),
-            'content_hash': content_hash,
-        }
-        self._save_page(url, page_data)
+        # Save page data
+        self._save_page(url, result['page_data'])
         
         # Update stats
         self.state.increment_stat('pages_crawled')
         
-        return new_urls
+        return result['links']
     
     def _process_document(self, url: str, depth: int) -> Optional[List[Tuple[str, int]]]:
         """
@@ -339,19 +309,16 @@ class Crawler:
                 self.state.mark_failed(url, depth)
                 return None
             
-            # Save document data
-            page_data = {
-                'url': url,
-                'title': result['title'] or Path(parsed.path).stem,
-                'description': f"PDF document, {result['pages']} pages",
-                'text': result['text'],
-                'headings': [],  # PDFs don't have structured headings
-                'depth': depth,
-                'crawled_at': time.time(),
-                'doc_type': 'pdf',
-                'doc_pages': result['pages'],
-                'doc_metadata': result['metadata']
-            }
+            # Build and save document data
+            page_data = build_document_data(
+                url=url,
+                title=result['title'] or Path(parsed.path).stem,
+                text=result['text'],
+                depth=depth,
+                doc_type='pdf',
+                doc_pages=result['pages'],
+                doc_metadata=result['metadata'],
+            )
             self._save_page(url, page_data)
             
             # Update stats
@@ -602,11 +569,4 @@ class Crawler:
         Args:
             warn_on_error: If True, print a warning for skipped corrupted files.
         """
-        for page_file in self.pages_dir.glob('*.json'):
-            try:
-                with open(page_file, 'r') as f:
-                    yield json.load(f)
-            except (json.JSONDecodeError, IOError) as e:
-                if warn_on_error:
-                    print(f"Warning: Skipping corrupted file {page_file}: {e}")
-                continue
+        yield from self._processor.iter_saved_pages(warn_on_error=warn_on_error)

--- a/doc_search/crawler/processor.py
+++ b/doc_search/crawler/processor.py
@@ -1,0 +1,331 @@
+"""
+Page processing module for the crawler.
+
+This module handles the processing of crawled page content, including:
+- HTML text extraction
+- Link extraction and filtering
+- Content hashing for change detection
+- Page metadata construction and persistence
+
+The PageProcessor class coordinates these operations and is used by the Crawler
+to transform raw HTML into structured page data.
+"""
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from ..parser import extract_text, extract_links
+from ..utils import url_to_filename
+
+
+def content_hash(content: str) -> str:
+    """
+    Generate SHA256 hash of content for change detection.
+    
+    Args:
+        content: The content string to hash.
+        
+    Returns:
+        Hex-encoded SHA256 hash of the content.
+    
+    Example:
+        >>> content_hash("Hello, World!")
+        'dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f'
+    """
+    return hashlib.sha256(content.encode('utf-8')).hexdigest()
+
+
+def build_page_data(
+    url: str,
+    extracted: Dict[str, Any],
+    depth: int,
+    *,
+    etag: Optional[str] = None,
+    last_modified: Optional[str] = None,
+    hash_value: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Build a page data dictionary from extracted content.
+    
+    Args:
+        url: The URL of the page.
+        extracted: Dict from extract_text() with keys: text, title, description, headings.
+        depth: The crawl depth at which this page was found.
+        etag: Optional ETag header value for incremental crawling.
+        last_modified: Optional Last-Modified header value for incremental crawling.
+        hash_value: Optional content hash for change detection.
+    
+    Returns:
+        A dictionary with all page data ready for persistence.
+    
+    Example:
+        >>> extracted = {'text': 'Hello', 'title': 'Test', 'description': '', 'headings': []}
+        >>> data = build_page_data('https://example.com', extracted, depth=0)
+        >>> data['url']
+        'https://example.com'
+        >>> data['title']
+        'Test'
+    """
+    return {
+        'url': url,
+        'title': extracted['title'],
+        'description': extracted['description'],
+        'text': extracted['text'],
+        'headings': extracted['headings'],
+        'depth': depth,
+        'crawled_at': time.time(),
+        # Incremental crawling metadata
+        'etag': etag,
+        'last_modified': last_modified,
+        'content_hash': hash_value,
+    }
+
+
+def build_document_data(
+    url: str,
+    title: str,
+    text: str,
+    depth: int,
+    *,
+    doc_type: str,
+    doc_pages: int = 0,
+    doc_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    Build page data for an extracted document (PDF, DOCX, etc.).
+    
+    Args:
+        url: The URL of the document.
+        title: The document title.
+        text: The extracted text content.
+        depth: The crawl depth at which this document was found.
+        doc_type: The document type (e.g., 'pdf', 'docx').
+        doc_pages: Number of pages in the document.
+        doc_metadata: Additional document metadata.
+    
+    Returns:
+        A dictionary with document data ready for persistence.
+    """
+    return {
+        'url': url,
+        'title': title,
+        'description': f"{doc_type.upper()} document, {doc_pages} pages",
+        'text': text,
+        'headings': [],  # Documents don't have structured HTML headings
+        'depth': depth,
+        'crawled_at': time.time(),
+        'doc_type': doc_type,
+        'doc_pages': doc_pages,
+        'doc_metadata': doc_metadata or {},
+    }
+
+
+class PageProcessor:
+    """
+    Processes crawled pages: extracts content, builds page data, handles persistence.
+    
+    This class coordinates the extraction of text and links from HTML content,
+    builds structured page data dictionaries, and handles saving/loading page
+    data to/from disk.
+    
+    Args:
+        pages_dir: Directory where page JSON files are stored.
+    
+    Example:
+        >>> processor = PageProcessor(Path('/data/pages'))
+        >>> result = processor.process_html('https://example.com', '<html>...</html>', depth=0)
+        >>> result['page_data']['title']
+        'Example Page'
+    """
+    
+    def __init__(self, pages_dir: Path):
+        """
+        Initialize the page processor.
+        
+        Args:
+            pages_dir: Directory for storing page JSON files.
+        """
+        self.pages_dir = Path(pages_dir)
+        self.pages_dir.mkdir(parents=True, exist_ok=True)
+    
+    def process_html(
+        self,
+        url: str,
+        html: str,
+        depth: int,
+        *,
+        base_url: Optional[str] = None,
+        etag: Optional[str] = None,
+        last_modified: Optional[str] = None,
+        link_filter: Optional[Callable[[str, int], bool]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Process HTML content and extract page data and links.
+        
+        This is the main entry point for processing a crawled HTML page.
+        It extracts text content, metadata, and links from the HTML.
+        
+        Args:
+            url: The URL of the page.
+            html: The raw HTML content.
+            depth: The crawl depth at which this page was found.
+            base_url: Base URL for resolving relative links (defaults to url).
+            etag: Optional ETag header for incremental crawling.
+            last_modified: Optional Last-Modified header for incremental crawling.
+            link_filter: Optional function(link, depth) -> bool to filter discovered links.
+        
+        Returns:
+            A dictionary with:
+            - page_data: The structured page data ready for saving.
+            - links: List of (url, depth) tuples for discovered links.
+            - content_hash: SHA256 hash of the HTML content.
+        
+        Example:
+            >>> result = processor.process_html(url, html, depth=1)
+            >>> result['page_data']['text']  # Extracted text
+            >>> result['links']  # [(url, depth), ...]
+        """
+        # Calculate content hash
+        hash_value = content_hash(html)
+        
+        # Extract text content and metadata
+        extracted = extract_text(html)
+        
+        # Extract links (use provided base_url or fall back to url)
+        resolve_base = base_url or url
+        all_links = extract_links(html, resolve_base)
+        
+        # Apply link filter if provided
+        new_depth = depth + 1
+        if link_filter:
+            links = [(link, new_depth) for link in all_links if link_filter(link, new_depth)]
+        else:
+            links = [(link, new_depth) for link in all_links]
+        
+        # Build page data
+        page_data = build_page_data(
+            url=url,
+            extracted=extracted,
+            depth=depth,
+            etag=etag,
+            last_modified=last_modified,
+            hash_value=hash_value,
+        )
+        
+        return {
+            'page_data': page_data,
+            'links': links,
+            'content_hash': hash_value,
+        }
+    
+    def is_content_changed(
+        self,
+        html: str,
+        existing_metadata: Optional[Dict[str, Any]],
+    ) -> Tuple[bool, str]:
+        """
+        Check if content has changed compared to existing metadata.
+        
+        Args:
+            html: The current HTML content.
+            existing_metadata: Previously saved page metadata, or None.
+        
+        Returns:
+            A tuple of (changed: bool, hash: str).
+            changed is True if content is new or different.
+        
+        Example:
+            >>> changed, hash_val = processor.is_content_changed(html, existing_meta)
+            >>> if not changed:
+            ...     print("Content unchanged, skipping")
+        """
+        hash_value = content_hash(html)
+        
+        if existing_metadata is None:
+            return True, hash_value
+        
+        existing_hash = existing_metadata.get('content_hash')
+        if existing_hash is None:
+            return True, hash_value
+        
+        return hash_value != existing_hash, hash_value
+    
+    def save_page(self, url: str, page_data: Dict[str, Any]) -> Path:
+        """
+        Save page data to disk.
+        
+        Args:
+            url: The URL of the page (used to generate filename).
+            page_data: The page data dictionary to save.
+        
+        Returns:
+            The path to the saved file.
+        """
+        filename = url_to_filename(url) + '.json'
+        filepath = self.pages_dir / filename
+        
+        with open(filepath, 'w') as f:
+            json.dump(page_data, f)
+        
+        return filepath
+    
+    def load_page_metadata(self, url: str) -> Optional[Dict[str, Any]]:
+        """
+        Load existing page metadata for incremental crawling.
+        
+        Args:
+            url: The URL of the page to load.
+        
+        Returns:
+            The page data dictionary, or None if not found or corrupted.
+        """
+        filename = url_to_filename(url) + '.json'
+        filepath = self.pages_dir / filename
+        
+        if not filepath.exists():
+            return None
+        
+        try:
+            with open(filepath, 'r') as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            return None
+    
+    def page_exists(self, url: str) -> bool:
+        """
+        Check if a page has been previously saved.
+        
+        Args:
+            url: The URL to check.
+        
+        Returns:
+            True if the page file exists, False otherwise.
+        """
+        filename = url_to_filename(url) + '.json'
+        filepath = self.pages_dir / filename
+        return filepath.exists()
+    
+    def iter_saved_pages(
+        self,
+        warn_on_error: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """
+        Iterate over all saved page data files.
+        
+        Args:
+            warn_on_error: If True, print warnings for corrupted files.
+        
+        Yields:
+            Page data dictionaries for each successfully loaded file.
+        """
+        for page_file in self.pages_dir.glob('*.json'):
+            try:
+                with open(page_file, 'r') as f:
+                    yield json.load(f)
+            except (json.JSONDecodeError, IOError) as e:
+                if warn_on_error:
+                    print(f"Warning: Skipping corrupted file {page_file}: {e}")
+                continue

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1469,29 +1469,29 @@ class TestIncrementalCrawl(CrawlerTestCase):
     """Tests for incremental crawling functionality."""
     
     def test_content_hash_deterministic(self):
-        """_content_hash should produce consistent hashes."""
-        crawler = self.create_crawler()
+        """content_hash should produce consistent hashes."""
+        from doc_search.crawler.processor import content_hash
         
         content = "Hello, World!"
-        hash1 = crawler._content_hash(content)
-        hash2 = crawler._content_hash(content)
+        hash1 = content_hash(content)
+        hash2 = content_hash(content)
         
         self.assertEqual(hash1, hash2)
     
     def test_content_hash_different_for_different_content(self):
-        """_content_hash should produce different hashes for different content."""
-        crawler = self.create_crawler()
+        """content_hash should produce different hashes for different content."""
+        from doc_search.crawler.processor import content_hash
         
-        hash1 = crawler._content_hash("Content A")
-        hash2 = crawler._content_hash("Content B")
+        hash1 = content_hash("Content A")
+        hash2 = content_hash("Content B")
         
         self.assertNotEqual(hash1, hash2)
     
     def test_content_hash_is_sha256(self):
-        """_content_hash should return 64-character SHA256 hash."""
-        crawler = self.create_crawler()
+        """content_hash should return 64-character SHA256 hash."""
+        from doc_search.crawler.processor import content_hash
         
-        hash_value = crawler._content_hash("Test content")
+        hash_value = content_hash("Test content")
         
         self.assertEqual(len(hash_value), 64)
         # Should be valid hex
@@ -1661,13 +1661,15 @@ class TestIncrementalCrawl(CrawlerTestCase):
     
     def test_unchanged_page_detection_via_content_hash(self):
         """Should detect unchanged pages via content hash comparison."""
+        from doc_search.crawler.processor import content_hash
+        
         crawler = self.create_crawler(incremental=True)
         
         # Simulate previously crawled page
         from doc_search.utils import url_to_filename
         url = 'https://example.com/page'
         content = '<html><head><title>Test</title></head><body>Content</body></html>'
-        content_hash = crawler._content_hash(content)
+        hash_value = content_hash(content)
         
         page_data = {
             'url': url,
@@ -1677,7 +1679,7 @@ class TestIncrementalCrawl(CrawlerTestCase):
             'headings': [],
             'depth': 0,
             'crawled_at': time.time(),
-            'content_hash': content_hash,
+            'content_hash': hash_value,
         }
         
         filename = url_to_filename(url) + '.json'
@@ -1686,21 +1688,21 @@ class TestIncrementalCrawl(CrawlerTestCase):
         
         # Load and verify
         loaded = crawler._get_page_metadata(url)
-        self.assertEqual(loaded['content_hash'], content_hash)
+        self.assertEqual(loaded['content_hash'], hash_value)
         
         # New content with same hash would be detected as unchanged
-        new_content_hash = crawler._content_hash(content)
+        new_content_hash = content_hash(content)
         self.assertEqual(new_content_hash, loaded['content_hash'])
     
     def test_changed_page_detection_via_content_hash(self):
         """Should detect changed pages via content hash comparison."""
-        crawler = self.create_crawler(incremental=True)
+        from doc_search.crawler.processor import content_hash
         
         original_content = '<html><body>Original</body></html>'
         modified_content = '<html><body>Modified</body></html>'
         
-        original_hash = crawler._content_hash(original_content)
-        modified_hash = crawler._content_hash(modified_content)
+        original_hash = content_hash(original_content)
+        modified_hash = content_hash(modified_content)
         
         # Hashes should be different
         self.assertNotEqual(original_hash, modified_hash)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,668 @@
+"""
+Tests for the page processor module.
+"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from doc_search.crawler.processor import (
+    PageProcessor,
+    content_hash,
+    build_page_data,
+    build_document_data,
+)
+
+
+# ============================================================================
+# Test Standalone Functions
+# ============================================================================
+
+class TestContentHash(unittest.TestCase):
+    """Tests for the content_hash function."""
+    
+    def test_hash_returns_string(self):
+        """content_hash should return a string."""
+        result = content_hash("Hello, World!")
+        self.assertIsInstance(result, str)
+    
+    def test_hash_is_64_chars(self):
+        """SHA256 hex digest should be 64 characters."""
+        result = content_hash("test content")
+        self.assertEqual(len(result), 64)
+    
+    def test_hash_is_deterministic(self):
+        """Same content should produce same hash."""
+        content = "The quick brown fox jumps over the lazy dog"
+        hash1 = content_hash(content)
+        hash2 = content_hash(content)
+        self.assertEqual(hash1, hash2)
+    
+    def test_hash_differs_for_different_content(self):
+        """Different content should produce different hash."""
+        hash1 = content_hash("content A")
+        hash2 = content_hash("content B")
+        self.assertNotEqual(hash1, hash2)
+    
+    def test_hash_empty_string(self):
+        """Empty string should produce a valid hash."""
+        result = content_hash("")
+        self.assertEqual(len(result), 64)
+    
+    def test_hash_unicode_content(self):
+        """Unicode content should be handled correctly."""
+        result = content_hash("Hello 世界 🌍")
+        self.assertEqual(len(result), 64)
+    
+    def test_hash_known_value(self):
+        """Known SHA256 hash value for verification."""
+        # SHA256 of "Hello, World!" is known
+        result = content_hash("Hello, World!")
+        expected = "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f"
+        self.assertEqual(result, expected)
+
+
+class TestBuildPageData(unittest.TestCase):
+    """Tests for the build_page_data function."""
+    
+    def test_basic_page_data(self):
+        """build_page_data should return a dict with required fields."""
+        extracted = {
+            'text': 'Page content',
+            'title': 'Test Page',
+            'description': 'A test page',
+            'headings': [(1, 'Heading 1')],
+        }
+        
+        result = build_page_data(
+            url='https://example.com/page',
+            extracted=extracted,
+            depth=1,
+        )
+        
+        self.assertEqual(result['url'], 'https://example.com/page')
+        self.assertEqual(result['title'], 'Test Page')
+        self.assertEqual(result['description'], 'A test page')
+        self.assertEqual(result['text'], 'Page content')
+        self.assertEqual(result['headings'], [(1, 'Heading 1')])
+        self.assertEqual(result['depth'], 1)
+        self.assertIsNotNone(result['crawled_at'])
+    
+    def test_page_data_with_etag(self):
+        """build_page_data should include etag when provided."""
+        extracted = {'text': '', 'title': '', 'description': '', 'headings': []}
+        
+        result = build_page_data(
+            url='https://example.com/',
+            extracted=extracted,
+            depth=0,
+            etag='"abc123"',
+        )
+        
+        self.assertEqual(result['etag'], '"abc123"')
+    
+    def test_page_data_with_last_modified(self):
+        """build_page_data should include last_modified when provided."""
+        extracted = {'text': '', 'title': '', 'description': '', 'headings': []}
+        
+        result = build_page_data(
+            url='https://example.com/',
+            extracted=extracted,
+            depth=0,
+            last_modified='Wed, 01 Jan 2025 00:00:00 GMT',
+        )
+        
+        self.assertEqual(result['last_modified'], 'Wed, 01 Jan 2025 00:00:00 GMT')
+    
+    def test_page_data_with_hash(self):
+        """build_page_data should include content_hash when provided."""
+        extracted = {'text': '', 'title': '', 'description': '', 'headings': []}
+        
+        result = build_page_data(
+            url='https://example.com/',
+            extracted=extracted,
+            depth=0,
+            hash_value='abc123hash',
+        )
+        
+        self.assertEqual(result['content_hash'], 'abc123hash')
+    
+    def test_page_data_defaults_to_none(self):
+        """Optional fields should default to None."""
+        extracted = {'text': '', 'title': '', 'description': '', 'headings': []}
+        
+        result = build_page_data(
+            url='https://example.com/',
+            extracted=extracted,
+            depth=0,
+        )
+        
+        self.assertIsNone(result['etag'])
+        self.assertIsNone(result['last_modified'])
+        self.assertIsNone(result['content_hash'])
+    
+    def test_crawled_at_is_recent(self):
+        """crawled_at should be a recent timestamp."""
+        import time
+        
+        extracted = {'text': '', 'title': '', 'description': '', 'headings': []}
+        
+        before = time.time()
+        result = build_page_data(
+            url='https://example.com/',
+            extracted=extracted,
+            depth=0,
+        )
+        after = time.time()
+        
+        self.assertGreaterEqual(result['crawled_at'], before)
+        self.assertLessEqual(result['crawled_at'], after)
+
+
+class TestBuildDocumentData(unittest.TestCase):
+    """Tests for the build_document_data function."""
+    
+    def test_basic_document_data(self):
+        """build_document_data should return a dict with required fields."""
+        result = build_document_data(
+            url='https://example.com/doc.pdf',
+            title='Test Document',
+            text='Document content here',
+            depth=2,
+            doc_type='pdf',
+            doc_pages=10,
+        )
+        
+        self.assertEqual(result['url'], 'https://example.com/doc.pdf')
+        self.assertEqual(result['title'], 'Test Document')
+        self.assertEqual(result['text'], 'Document content here')
+        self.assertEqual(result['depth'], 2)
+        self.assertEqual(result['doc_type'], 'pdf')
+        self.assertEqual(result['doc_pages'], 10)
+        self.assertEqual(result['description'], 'PDF document, 10 pages')
+        self.assertEqual(result['headings'], [])
+        self.assertIsNotNone(result['crawled_at'])
+    
+    def test_document_data_with_metadata(self):
+        """build_document_data should include doc_metadata when provided."""
+        metadata = {'author': 'John Doe', 'created': '2025-01-01'}
+        
+        result = build_document_data(
+            url='https://example.com/doc.pdf',
+            title='Test',
+            text='Content',
+            depth=0,
+            doc_type='pdf',
+            doc_metadata=metadata,
+        )
+        
+        self.assertEqual(result['doc_metadata'], metadata)
+    
+    def test_document_data_default_metadata(self):
+        """doc_metadata should default to empty dict."""
+        result = build_document_data(
+            url='https://example.com/doc.pdf',
+            title='Test',
+            text='Content',
+            depth=0,
+            doc_type='pdf',
+        )
+        
+        self.assertEqual(result['doc_metadata'], {})
+    
+    def test_document_data_default_pages(self):
+        """doc_pages should default to 0."""
+        result = build_document_data(
+            url='https://example.com/doc.pdf',
+            title='Test',
+            text='Content',
+            depth=0,
+            doc_type='pdf',
+        )
+        
+        self.assertEqual(result['doc_pages'], 0)
+        self.assertEqual(result['description'], 'PDF document, 0 pages')
+    
+    def test_document_data_docx_type(self):
+        """build_document_data should work for DOCX type."""
+        result = build_document_data(
+            url='https://example.com/doc.docx',
+            title='Word Doc',
+            text='Word content',
+            depth=1,
+            doc_type='docx',
+            doc_pages=5,
+        )
+        
+        self.assertEqual(result['doc_type'], 'docx')
+        self.assertEqual(result['description'], 'DOCX document, 5 pages')
+
+
+# ============================================================================
+# Test PageProcessor Class
+# ============================================================================
+
+class TestPageProcessorInit(unittest.TestCase):
+    """Tests for PageProcessor initialization."""
+    
+    def test_init_creates_directory(self):
+        """PageProcessor should create pages_dir if it doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pages_dir = Path(tmpdir) / 'new_pages'
+            self.assertFalse(pages_dir.exists())
+            
+            processor = PageProcessor(pages_dir)
+            
+            self.assertTrue(pages_dir.exists())
+            self.assertEqual(processor.pages_dir, pages_dir)
+    
+    def test_init_uses_existing_directory(self):
+        """PageProcessor should work with existing directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pages_dir = Path(tmpdir) / 'pages'
+            pages_dir.mkdir()
+            
+            processor = PageProcessor(pages_dir)
+            
+            self.assertEqual(processor.pages_dir, pages_dir)
+    
+    def test_init_accepts_string_path(self):
+        """PageProcessor should accept string paths."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pages_dir = str(Path(tmpdir) / 'pages')
+            
+            processor = PageProcessor(pages_dir)
+            
+            self.assertEqual(processor.pages_dir, Path(pages_dir))
+
+
+class TestPageProcessorProcessHtml(unittest.TestCase):
+    """Tests for PageProcessor.process_html method."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.tmpdir = tempfile.mkdtemp()
+        self.pages_dir = Path(self.tmpdir) / 'pages'
+        self.processor = PageProcessor(self.pages_dir)
+    
+    def tearDown(self):
+        """Clean up test fixtures."""
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+    
+    def test_process_html_returns_dict(self):
+        """process_html should return a dict with expected keys."""
+        html = '<html><title>Test</title><body>Hello</body></html>'
+        
+        result = self.processor.process_html(
+            url='https://example.com/page',
+            html=html,
+            depth=0,
+        )
+        
+        self.assertIn('page_data', result)
+        self.assertIn('links', result)
+        self.assertIn('content_hash', result)
+    
+    def test_process_html_extracts_title(self):
+        """process_html should extract the page title."""
+        html = '<html><title>My Page Title</title><body>Content</body></html>'
+        
+        result = self.processor.process_html(
+            url='https://example.com/',
+            html=html,
+            depth=0,
+        )
+        
+        self.assertEqual(result['page_data']['title'], 'My Page Title')
+    
+    def test_process_html_extracts_text(self):
+        """process_html should extract text content."""
+        html = '<html><body><p>Hello World</p></body></html>'
+        
+        result = self.processor.process_html(
+            url='https://example.com/',
+            html=html,
+            depth=0,
+        )
+        
+        self.assertIn('Hello World', result['page_data']['text'])
+    
+    def test_process_html_extracts_links(self):
+        """process_html should extract links from HTML."""
+        html = '''
+        <html><body>
+            <a href="/page1">Link 1</a>
+            <a href="/page2">Link 2</a>
+        </body></html>
+        '''
+        
+        result = self.processor.process_html(
+            url='https://example.com/',
+            html=html,
+            depth=0,
+        )
+        
+        links = [url for url, depth in result['links']]
+        self.assertIn('https://example.com/page1', links)
+        self.assertIn('https://example.com/page2', links)
+    
+    def test_process_html_increments_link_depth(self):
+        """Discovered links should have depth + 1."""
+        html = '<html><body><a href="/page">Link</a></body></html>'
+        
+        result = self.processor.process_html(
+            url='https://example.com/',
+            html=html,
+            depth=2,
+        )
+        
+        for url, depth in result['links']:
+            self.assertEqual(depth, 3)
+    
+    def test_process_html_with_link_filter(self):
+        """process_html should apply link filter."""
+        html = '''
+        <html><body>
+            <a href="/allowed">Allowed</a>
+            <a href="/blocked">Blocked</a>
+        </body></html>
+        '''
+        
+        def link_filter(url, depth):
+            return 'allowed' in url
+        
+        result = self.processor.process_html(
+            url='https://example.com/',
+            html=html,
+            depth=0,
+            link_filter=link_filter,
+        )
+        
+        links = [url for url, depth in result['links']]
+        self.assertIn('https://example.com/allowed', links)
+        self.assertNotIn('https://example.com/blocked', links)
+    
+    def test_process_html_includes_content_hash(self):
+        """process_html should include content hash."""
+        html = '<html><body>Test content</body></html>'
+        
+        result = self.processor.process_html(
+            url='https://example.com/',
+            html=html,
+            depth=0,
+        )
+        
+        self.assertEqual(len(result['content_hash']), 64)
+        self.assertEqual(result['page_data']['content_hash'], result['content_hash'])
+    
+    def test_process_html_includes_incremental_metadata(self):
+        """process_html should include etag and last_modified."""
+        html = '<html><body>Content</body></html>'
+        
+        result = self.processor.process_html(
+            url='https://example.com/',
+            html=html,
+            depth=0,
+            etag='"abc123"',
+            last_modified='Wed, 01 Jan 2025 00:00:00 GMT',
+        )
+        
+        self.assertEqual(result['page_data']['etag'], '"abc123"')
+        self.assertEqual(result['page_data']['last_modified'], 'Wed, 01 Jan 2025 00:00:00 GMT')
+    
+    def test_process_html_uses_base_url_for_links(self):
+        """process_html should use base_url for resolving links."""
+        html = '<html><body><a href="/page">Link</a></body></html>'
+        
+        result = self.processor.process_html(
+            url='https://example.com/current',
+            html=html,
+            depth=0,
+            base_url='https://other.com/',
+        )
+        
+        links = [url for url, depth in result['links']]
+        self.assertIn('https://other.com/page', links)
+
+
+class TestPageProcessorIsContentChanged(unittest.TestCase):
+    """Tests for PageProcessor.is_content_changed method."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.tmpdir = tempfile.mkdtemp()
+        self.processor = PageProcessor(Path(self.tmpdir) / 'pages')
+    
+    def tearDown(self):
+        """Clean up test fixtures."""
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+    
+    def test_content_changed_when_no_existing_metadata(self):
+        """Content should be considered changed when no existing metadata."""
+        changed, hash_val = self.processor.is_content_changed(
+            html='<html>Content</html>',
+            existing_metadata=None,
+        )
+        
+        self.assertTrue(changed)
+        self.assertEqual(len(hash_val), 64)
+    
+    def test_content_changed_when_no_existing_hash(self):
+        """Content should be considered changed when existing metadata has no hash."""
+        changed, hash_val = self.processor.is_content_changed(
+            html='<html>Content</html>',
+            existing_metadata={'url': 'https://example.com'},
+        )
+        
+        self.assertTrue(changed)
+    
+    def test_content_unchanged_when_hash_matches(self):
+        """Content should be unchanged when hash matches."""
+        html = '<html>Same content</html>'
+        hash_val = content_hash(html)
+        
+        changed, new_hash = self.processor.is_content_changed(
+            html=html,
+            existing_metadata={'content_hash': hash_val},
+        )
+        
+        self.assertFalse(changed)
+        self.assertEqual(new_hash, hash_val)
+    
+    def test_content_changed_when_hash_differs(self):
+        """Content should be changed when hash differs."""
+        changed, hash_val = self.processor.is_content_changed(
+            html='<html>New content</html>',
+            existing_metadata={'content_hash': 'old_hash_value'},
+        )
+        
+        self.assertTrue(changed)
+
+
+class TestPageProcessorPersistence(unittest.TestCase):
+    """Tests for PageProcessor save/load methods."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.tmpdir = tempfile.mkdtemp()
+        self.pages_dir = Path(self.tmpdir) / 'pages'
+        self.processor = PageProcessor(self.pages_dir)
+    
+    def tearDown(self):
+        """Clean up test fixtures."""
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+    
+    def test_save_page_creates_file(self):
+        """save_page should create a JSON file."""
+        url = 'https://example.com/page'
+        data = {'url': url, 'title': 'Test', 'text': 'Content'}
+        
+        filepath = self.processor.save_page(url, data)
+        
+        self.assertTrue(filepath.exists())
+        self.assertTrue(filepath.suffix == '.json')
+    
+    def test_save_and_load_roundtrip(self):
+        """Data should survive save/load roundtrip."""
+        url = 'https://example.com/page'
+        data = {
+            'url': url,
+            'title': 'Test Page',
+            'text': 'Page content',
+            'headings': [(1, 'Heading')],
+            'depth': 2,
+        }
+        
+        self.processor.save_page(url, data)
+        loaded = self.processor.load_page_metadata(url)
+        
+        self.assertEqual(loaded['url'], data['url'])
+        self.assertEqual(loaded['title'], data['title'])
+        self.assertEqual(loaded['text'], data['text'])
+        self.assertEqual(loaded['depth'], data['depth'])
+    
+    def test_load_nonexistent_page_returns_none(self):
+        """load_page_metadata should return None for nonexistent pages."""
+        result = self.processor.load_page_metadata('https://example.com/nonexistent')
+        
+        self.assertIsNone(result)
+    
+    def test_load_corrupted_file_returns_none(self):
+        """load_page_metadata should return None for corrupted files."""
+        from doc_search.utils import url_to_filename
+        
+        url = 'https://example.com/corrupted'
+        filename = url_to_filename(url) + '.json'
+        filepath = self.pages_dir / filename
+        
+        # Write invalid JSON
+        with open(filepath, 'w') as f:
+            f.write('not valid json{{{')
+        
+        result = self.processor.load_page_metadata(url)
+        
+        self.assertIsNone(result)
+    
+    def test_page_exists_returns_true_for_saved_page(self):
+        """page_exists should return True for saved pages."""
+        url = 'https://example.com/page'
+        self.processor.save_page(url, {'url': url})
+        
+        self.assertTrue(self.processor.page_exists(url))
+    
+    def test_page_exists_returns_false_for_unsaved_page(self):
+        """page_exists should return False for unsaved pages."""
+        self.assertFalse(self.processor.page_exists('https://example.com/unsaved'))
+
+
+class TestPageProcessorIterSavedPages(unittest.TestCase):
+    """Tests for PageProcessor.iter_saved_pages method."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.tmpdir = tempfile.mkdtemp()
+        self.pages_dir = Path(self.tmpdir) / 'pages'
+        self.processor = PageProcessor(self.pages_dir)
+    
+    def tearDown(self):
+        """Clean up test fixtures."""
+        import shutil
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+    
+    def test_iter_empty_directory(self):
+        """iter_saved_pages should yield nothing for empty directory."""
+        pages = list(self.processor.iter_saved_pages())
+        self.assertEqual(len(pages), 0)
+    
+    def test_iter_yields_all_pages(self):
+        """iter_saved_pages should yield all saved pages."""
+        urls = [
+            'https://example.com/page1',
+            'https://example.com/page2',
+            'https://example.com/page3',
+        ]
+        
+        for url in urls:
+            self.processor.save_page(url, {'url': url})
+        
+        pages = list(self.processor.iter_saved_pages())
+        page_urls = {p['url'] for p in pages}
+        
+        self.assertEqual(len(pages), 3)
+        for url in urls:
+            self.assertIn(url, page_urls)
+    
+    def test_iter_skips_corrupted_files(self):
+        """iter_saved_pages should skip corrupted files."""
+        from doc_search.utils import url_to_filename
+        
+        # Save valid page
+        self.processor.save_page('https://example.com/valid', {'url': 'valid'})
+        
+        # Create corrupted file
+        corrupted_path = self.pages_dir / 'corrupted.json'
+        with open(corrupted_path, 'w') as f:
+            f.write('invalid json')
+        
+        pages = list(self.processor.iter_saved_pages(warn_on_error=False))
+        
+        self.assertEqual(len(pages), 1)
+        self.assertEqual(pages[0]['url'], 'valid')
+    
+    def test_iter_warns_on_corrupted_files(self):
+        """iter_saved_pages should warn about corrupted files when warn_on_error=True."""
+        # Create corrupted file
+        corrupted_path = self.pages_dir / 'corrupted.json'
+        with open(corrupted_path, 'w') as f:
+            f.write('invalid json')
+        
+        with patch('builtins.print') as mock_print:
+            list(self.processor.iter_saved_pages(warn_on_error=True))
+            mock_print.assert_called()
+            call_arg = str(mock_print.call_args)
+            self.assertIn('Warning', call_arg)
+
+
+# ============================================================================
+# Test Module Exports
+# ============================================================================
+
+class TestModuleExports(unittest.TestCase):
+    """Tests for module exports."""
+    
+    def test_can_import_from_processor(self):
+        """All public items should be importable from processor."""
+        from doc_search.crawler.processor import (
+            PageProcessor,
+            content_hash,
+            build_page_data,
+            build_document_data,
+        )
+        
+        self.assertIsNotNone(PageProcessor)
+        self.assertIsNotNone(content_hash)
+        self.assertIsNotNone(build_page_data)
+        self.assertIsNotNone(build_document_data)
+    
+    def test_can_import_from_crawler_package(self):
+        """All public items should be importable from crawler package."""
+        from doc_search.crawler import (
+            PageProcessor,
+            content_hash,
+            build_page_data,
+            build_document_data,
+        )
+        
+        self.assertIsNotNone(PageProcessor)
+        self.assertIsNotNone(content_hash)
+        self.assertIsNotNone(build_page_data)
+        self.assertIsNotNone(build_document_data)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Extracts page processing logic from `_crawler.py` into a dedicated `processor.py` module as part of the Phase 6 crawler refactoring.

## Changes

### New Module: `doc_search/crawler/processor.py`

**Standalone Functions:**
- `content_hash(content: str)` - SHA256 hashing for change detection
- `build_page_data(...)` - Construct page data dictionaries for HTML pages
- `build_document_data(...)` - Construct page data for documents (PDF/DOCX)

**PageProcessor Class:**
- `process_html(url, html, depth, ...)` - Coordinate text/link extraction and page data building
- `is_content_changed(html, existing_metadata)` - Check if content has changed for incremental crawling
- `save_page(url, page_data)` - Persist page data to disk
- `load_page_metadata(url)` - Load existing page metadata
- `page_exists(url)` - Check if page was previously saved
- `iter_saved_pages(warn_on_error)` - Iterate over all saved page files

### Updated Files

- **`_crawler.py`**: Now uses PageProcessor for page processing, persistence, and change detection
- **`__init__.py`**: Exports new processor module symbols
- **`tests/test_crawler.py`**: Updated tests to use `content_hash` function from processor

### Test Coverage

- Added 46 new tests in `tests/test_processor.py`
- All 955 tests pass

## Testing

```bash
source .venv/bin/activate && PYTHONPATH=. pytest
```

Closes #97