### PR TITLE
feat: Add Spell Check ('Did you mean...') to Web UI

### DIFF
--- a/doc_search/server.py
+++ b/doc_search/server.py
@@ -306,6 +306,37 @@ a:hover {
     opacity: 0.5;
 }
 
+/* Spell check suggestion */
+.spell-suggestion {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.spell-suggestion-icon {
+    font-size: 1.25rem;
+}
+
+.spell-suggestion-text {
+    color: var(--text-secondary);
+}
+
+.spell-suggestion-link {
+    color: var(--accent);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.spell-suggestion-link:hover {
+    color: var(--accent-hover);
+    text-decoration: underline;
+}
+
 /* Tips */
 .tips {
     background: var(--bg-secondary);
@@ -450,13 +481,26 @@ def render_page(
     show_scores: bool = True,
     page: int = 1,
     per_page: int = 10,
-    total_results: int = 0
+    total_results: int = 0,
+    suggestion: Optional[str] = None
 ) -> str:
     """Render the full HTML page."""
     
     stats = stats or {}
     total_docs = stats.get('total_documents', 0)
     unique_terms = stats.get('unique_terms', 0)
+    
+    # Build spell check suggestion HTML
+    suggestion_html = ""
+    if suggestion:
+        encoded_suggestion = urllib.parse.quote(suggestion)
+        suggestion_html = f'''
+        <div class="spell-suggestion">
+            <span class="spell-suggestion-icon">💡</span>
+            <span class="spell-suggestion-text">Did you mean:</span>
+            <a href="/?q={encoded_suggestion}" class="spell-suggestion-link">{escape(suggestion)}</a>?
+        </div>
+        '''
     
     # Build results HTML
     if query and results is not None:
@@ -534,7 +578,7 @@ def render_page(
                 
                 results_html += '</div>'
         else:
-            results_html = '''
+            results_html = suggestion_html + '''
             <div class="no-results">
                 <div class="no-results-icon">🔍</div>
                 <div>No results found. Try different keywords.</div>
@@ -695,6 +739,14 @@ class SearchHandler(BaseHTTPRequestHandler):
                 page = 1
                 page_results = all_results[:per_page]
             
+            # Check for spelling suggestions when results are low
+            suggestion = None
+            if total_results == 0 and hasattr(self.engine, 'get_spelling_suggestion'):
+                suggestion = self.engine.get_spelling_suggestion(query)
+                # Only show suggestion if it's different from the query
+                if suggestion and suggestion.lower() == query.lower():
+                    suggestion = None
+            
             html_content = render_page(
                 query=query,
                 results=page_results,
@@ -702,7 +754,8 @@ class SearchHandler(BaseHTTPRequestHandler):
                 stats=stats,
                 page=page,
                 per_page=per_page,
-                total_results=total_results
+                total_results=total_results,
+                suggestion=suggestion
             )
         else:
             # Welcome page

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -50,6 +50,28 @@ class MockSearchEngine:
         return self._stats
 
 
+class MockEnhancedSearchEngine(MockSearchEngine):
+    """Mock EnhancedSearchEngine with spell check support."""
+    
+    def __init__(self, results: Optional[List[Dict[str, Any]]] = None,
+                 stats: Optional[Dict[str, Any]] = None,
+                 spelling_suggestion: Optional[str] = None):
+        """
+        Create mock enhanced search engine.
+        
+        Args:
+            results: List of result dicts to return from search()
+            stats: Stats dict to return from get_stats()
+            spelling_suggestion: Spelling suggestion to return (or None)
+        """
+        super().__init__(results, stats)
+        self._spelling_suggestion = spelling_suggestion
+    
+    def get_spelling_suggestion(self, query: str) -> Optional[str]:
+        """Return mock spelling suggestion."""
+        return self._spelling_suggestion
+
+
 def get_free_port() -> int:
     """Find an available port for testing."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -758,6 +780,191 @@ class TestHealthEndpointUnhealthy(ServerTestCase):
         data = json.loads(body)
         self.assertIn('reason', data)
         self.assertIn('documents', data['reason'].lower())
+
+
+# ============================================================================
+# Issue #149: Spell Check ("Did you mean...") Tests
+# ============================================================================
+
+class TestRenderPageSpellSuggestion(unittest.TestCase):
+    """Tests for spell check suggestion rendering."""
+    
+    def test_renders_suggestion_when_provided(self):
+        """Should render 'Did you mean' when suggestion provided."""
+        html = render_page(
+            query='pyhton',
+            results=[],
+            suggestion='python'
+        )
+        
+        self.assertIn('Did you mean', html)
+        self.assertIn('python', html)
+        self.assertIn('spell-suggestion', html)
+    
+    def test_suggestion_is_clickable_link(self):
+        """Suggestion should be a clickable link."""
+        html = render_page(
+            query='pyhton',
+            results=[],
+            suggestion='python'
+        )
+        
+        # Should have a link to search with the suggestion
+        self.assertIn('href="/?q=python"', html)
+        self.assertIn('spell-suggestion-link', html)
+    
+    def test_no_suggestion_when_none(self):
+        """Should not render suggestion section when None."""
+        html = render_page(
+            query='test',
+            results=[],
+            suggestion=None
+        )
+        
+        self.assertNotIn('Did you mean', html)
+        # Check for the div element, not just the CSS class name
+        self.assertNotIn('<div class="spell-suggestion">', html)
+    
+    def test_suggestion_escapes_special_chars(self):
+        """Suggestion should be HTML escaped."""
+        html = render_page(
+            query='test',
+            results=[],
+            suggestion='<script>alert(1)</script>'
+        )
+        
+        self.assertNotIn('<script>alert', html)
+        self.assertIn('&lt;script&gt;', html)
+    
+    def test_suggestion_url_encoded_in_link(self):
+        """Suggestion with spaces should be URL encoded in link."""
+        html = render_page(
+            query='pyhton async',
+            results=[],
+            suggestion='python async'
+        )
+        
+        # The link href should have URL-encoded spaces
+        self.assertIn('href="/?q=python%20async"', html)
+
+
+class TestServerSpellCheckSuggestion(ServerTestCase):
+    """Tests for spell check suggestion in server responses."""
+    
+    @classmethod
+    def setUpClass(cls):
+        """Start test server with enhanced engine that returns spell suggestions."""
+        # No results, but has a spelling suggestion
+        cls.engine = MockEnhancedSearchEngine(
+            results=[],
+            spelling_suggestion='python'
+        )
+        cls.start_server(engine=cls.engine)
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Stop test server."""
+        cls.stop_server()
+    
+    def test_shows_suggestion_on_no_results(self):
+        """Should show 'Did you mean' when no results and suggestion available."""
+        status, headers, body = self.make_request('/?q=pyhton')
+        
+        self.assertEqual(status, 200)
+        self.assertIn('Did you mean', body)
+        self.assertIn('python', body)
+    
+    def test_suggestion_link_is_clickable(self):
+        """Suggestion link should point to corrected query."""
+        status, headers, body = self.make_request('/?q=pyhton')
+        
+        self.assertIn('href="/?q=python"', body)
+
+
+class TestServerSpellCheckNoSuggestion(ServerTestCase):
+    """Tests for server when spell check returns no suggestion."""
+    
+    @classmethod
+    def setUpClass(cls):
+        """Start test server with enhanced engine that returns no suggestion."""
+        cls.engine = MockEnhancedSearchEngine(
+            results=[],
+            spelling_suggestion=None
+        )
+        cls.start_server(engine=cls.engine)
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Stop test server."""
+        cls.stop_server()
+    
+    def test_no_suggestion_shown_when_none_available(self):
+        """Should not show suggestion when engine returns None."""
+        status, headers, body = self.make_request('/?q=xyzabc123')
+        
+        self.assertEqual(status, 200)
+        self.assertNotIn('Did you mean', body)
+        self.assertNotIn('<div class="spell-suggestion">', body)
+        # Should still show no results message
+        self.assertIn('No results found', body)
+
+
+class TestServerSpellCheckWithResults(ServerTestCase):
+    """Tests for spell check when results are found."""
+    
+    @classmethod
+    def setUpClass(cls):
+        """Start test server with results (no suggestion needed)."""
+        mock_results = [
+            {'url': 'https://example.com/test', 'title': 'Test Page', 'score': 1.0}
+        ]
+        cls.engine = MockEnhancedSearchEngine(
+            results=mock_results,
+            spelling_suggestion='python'  # Suggestion exists but shouldn't show
+        )
+        cls.start_server(engine=cls.engine)
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Stop test server."""
+        cls.stop_server()
+    
+    def test_no_suggestion_shown_when_results_found(self):
+        """Should not show suggestion when results are found."""
+        status, headers, body = self.make_request('/?q=test')
+        
+        self.assertEqual(status, 200)
+        # Should show results
+        self.assertIn('Test Page', body)
+        # Should NOT show spell suggestion (results were found)
+        self.assertNotIn('Did you mean', body)
+        self.assertNotIn('<div class="spell-suggestion">', body)
+
+
+class TestServerWithBasicEngine(ServerTestCase):
+    """Tests that basic SearchEngine (without spell check) still works."""
+    
+    @classmethod
+    def setUpClass(cls):
+        """Start test server with basic engine (no spell check)."""
+        cls.engine = MockSearchEngine(results=[])
+        cls.start_server(engine=cls.engine)
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Stop test server."""
+        cls.stop_server()
+    
+    def test_works_without_spell_check_method(self):
+        """Server should work when engine lacks get_spelling_suggestion."""
+        status, headers, body = self.make_request('/?q=test')
+        
+        self.assertEqual(status, 200)
+        # Should show no results without crashing
+        self.assertIn('No results found', body)
+        # No spell suggestion shown (engine doesn't have the method)
+        self.assertNotIn('Did you mean', body)
+        self.assertNotIn('<div class="spell-suggestion">', body)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #149

## Summary
Adds spell check suggestions to the web UI when search returns no results.

## Changes
- Modified `server.py` to check for spelling suggestions when results are 0
- Added CSS styles for the ".spell-suggestion" display
- Suggestion displays as: "Did you mean: **python**?" with clickable link
- Clicking the suggestion re-runs the search with the corrected query
- Works with `EnhancedSearchEngine.get_spelling_suggestion()` method
- Gracefully handles basic `SearchEngine` that lacks spell check

## Acceptance Criteria
- [x] Spell check suggestions shown when 0 results
- [x] Clicking suggestion re-runs search with corrected query
- [x] Works with EnhancedSearchEngine
- [x] Tests added for spell check in web UI
- [x] No JavaScript required

## Testing
- Added 9 new test cases for spell check UI functionality
- All 965 existing tests continue to pass