### PR TITLE
feat: Add Synonym Expansion Toggle to Web UI

### DIFF
--- a/doc_search/cli/parsers.py
+++ b/doc_search/cli/parsers.py
@@ -206,4 +206,10 @@ def _add_serve_parser(subparsers):
                              help='Maximum total results for pagination (default: 100)')
     serve_parser.add_argument('--separate-paths', action='store_true',
                              help='Use if site was crawled with --separate-paths')
+    serve_parser.add_argument('--enable-synonyms', action='store_true', default=True,
+                             dest='enable_synonyms',
+                             help='Enable synonym expansion toggle (default: enabled)')
+    serve_parser.add_argument('--disable-synonyms', action='store_false',
+                             dest='enable_synonyms',
+                             help='Disable synonym expansion toggle')
     serve_parser.set_defaults(func=cmd_serve)

--- a/doc_search/server.py
+++ b/doc_search/server.py
@@ -164,6 +164,34 @@ a:hover {
     transform: scale(0.98);
 }
 
+/* Search options (synonym toggle) */
+.search-options {
+    margin-top: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.synonym-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+}
+
+.synonym-toggle input[type="checkbox"] {
+    width: 1rem;
+    height: 1rem;
+    accent-color: var(--accent);
+    cursor: pointer;
+}
+
+.synonym-toggle:hover {
+    color: var(--text-primary);
+}
+
 /* Results info */
 .results-info {
     display: flex;
@@ -547,13 +575,28 @@ def render_page(
     suggestion: Optional[str] = None,
     facets: Optional[Dict[str, Dict[str, int]]] = None,
     active_facet: Optional[str] = None,
-    total_unfiltered: int = 0
+    total_unfiltered: int = 0,
+    synonyms_active: bool = False,
+    show_synonym_toggle: bool = False
 ) -> str:
     """Render the full HTML page."""
     
     stats = stats or {}
     total_docs = stats.get('total_documents', 0)
     unique_terms = stats.get('unique_terms', 0)
+    
+    # Build synonym toggle HTML
+    synonym_toggle_html = ""
+    if show_synonym_toggle:
+        checked = 'checked' if synonyms_active else ''
+        synonym_toggle_html = f'''
+            <div class="search-options">
+                <label class="synonym-toggle">
+                    <input type="checkbox" name="synonyms" value="1" {checked}>
+                    <span>Expand synonyms</span>
+                </label>
+            </div>
+        '''
     
     # Build facet filter HTML
     facets_html = ""
@@ -723,6 +766,7 @@ def render_page(
                 >
                 <button type="submit" class="search-button">Search</button>
             </div>
+            {synonym_toggle_html}
         </form>
         
         {results_html}
@@ -758,6 +802,7 @@ class SearchHandler(BaseHTTPRequestHandler):
     start_time: float = None  # Server start time for uptime calculation
     enable_autocomplete: bool = True  # Enable /suggest endpoint
     enable_facets: bool = True  # Enable faceted search filtering
+    enable_synonyms: bool = True  # Enable synonym expansion toggle
     
     def log_message(self, format, *args):
         """Log HTTP requests if enabled."""
@@ -813,6 +858,12 @@ class SearchHandler(BaseHTTPRequestHandler):
         # Get facet filter (category)
         category_filter = query_params.get('category', [''])[0].strip() if self.enable_facets else ''
         
+        # Get synonym toggle state (synonyms=1 enables expansion)
+        synonyms_active = False
+        if self.enable_synonyms:
+            synonyms_param = query_params.get('synonyms', [''])[0].strip()
+            synonyms_active = synonyms_param == '1'
+        
         per_page = self.per_page
         max_results = self.max_results
         
@@ -822,7 +873,16 @@ class SearchHandler(BaseHTTPRequestHandler):
         if query:
             # Perform search - fetch enough for pagination
             search_start = time.perf_counter()
-            all_results = self.engine.search(query, top_k=max_results)
+            # Pass expand_synonyms if engine supports it (EnhancedSearchEngine)
+            if synonyms_active and hasattr(self.engine, 'search'):
+                import inspect
+                sig = inspect.signature(self.engine.search)
+                if 'expand_synonyms' in sig.parameters:
+                    all_results = self.engine.search(query, top_k=max_results, expand_synonyms=True)
+                else:
+                    all_results = self.engine.search(query, top_k=max_results)
+            else:
+                all_results = self.engine.search(query, top_k=max_results)
             elapsed_ms = (time.perf_counter() - search_start) * 1000
             
             # Get facet counts before filtering (for accurate counts)
@@ -870,11 +930,13 @@ class SearchHandler(BaseHTTPRequestHandler):
                 suggestion=suggestion,
                 facets=facets,
                 active_facet=category_filter if category_filter else None,
-                total_unfiltered=total_unfiltered
+                total_unfiltered=total_unfiltered,
+                synonyms_active=synonyms_active,
+                show_synonym_toggle=self.enable_synonyms
             )
         else:
             # Welcome page
-            html_content = render_page(stats=stats)
+            html_content = render_page(stats=stats, show_synonym_toggle=self.enable_synonyms)
         
         self.send_html(html_content)
     
@@ -964,7 +1026,8 @@ def run_server(
     per_page: int = 10,
     max_results: int = 100,
     enable_autocomplete: bool = True,
-    enable_facets: bool = True
+    enable_facets: bool = True,
+    enable_synonyms: bool = True
 ) -> HTTPServer:
     """Create and return the HTTP server (doesn't start it).
     
@@ -978,6 +1041,7 @@ def run_server(
         max_results: Maximum total results for pagination (default: 100)
         enable_autocomplete: If True, enable /suggest endpoint (default: True)
         enable_facets: If True, enable faceted search filtering (default: True)
+        enable_synonyms: If True, show synonym expansion toggle (default: True)
         
     Returns:
         HTTPServer instance (call serve_forever() to start)
@@ -990,5 +1054,6 @@ def run_server(
     SearchHandler.start_time = time.time()  # Record server start time
     SearchHandler.enable_facets = enable_facets
     SearchHandler.enable_autocomplete = enable_autocomplete
+    SearchHandler.enable_synonyms = enable_synonyms
     server = HTTPServer((host, port), SearchHandler)
     return server

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -51,13 +51,14 @@ class MockSearchEngine:
 
 
 class MockEnhancedSearchEngine(MockSearchEngine):
-    """Mock EnhancedSearchEngine with autocomplete, spell check, and facet support."""
+    """Mock EnhancedSearchEngine with autocomplete, spell check, facet, and synonym support."""
     
     def __init__(self, results: Optional[List[Dict[str, Any]]] = None,
                  stats: Optional[Dict[str, Any]] = None,
                  autocomplete_suggestions: Optional[List[str]] = None,
                  spelling_suggestion: Optional[str] = None,
-                 facet_counts: Optional[Dict[str, Dict[str, int]]] = None):
+                 facet_counts: Optional[Dict[str, Dict[str, int]]] = None,
+                 synonym_results: Optional[List[Dict[str, Any]]] = None):
         """
         Create mock enhanced search engine.
         
@@ -67,11 +68,22 @@ class MockEnhancedSearchEngine(MockSearchEngine):
             autocomplete_suggestions: List of suggestions to return
             spelling_suggestion: Spelling suggestion to return (or None)
             facet_counts: Facet counts to return from get_facet_counts()
+            synonym_results: Results to return when synonyms expanded (or None for same as results)
         """
         super().__init__(results, stats)
         self._autocomplete_suggestions = autocomplete_suggestions or []
         self._spelling_suggestion = spelling_suggestion
         self._facet_counts = facet_counts or {}
+        self._synonym_results = synonym_results
+        self._last_expand_synonyms = None
+    
+    def search(self, query: str, top_k: int = 10, expand_synonyms: bool = False) -> List[Dict[str, Any]]:
+        """Search with optional synonym expansion."""
+        self._last_expand_synonyms = expand_synonyms
+        self.search_calls.append({'query': query, 'top_k': top_k, 'expand_synonyms': expand_synonyms})
+        if expand_synonyms and self._synonym_results is not None:
+            return self._synonym_results[:top_k]
+        return self._results[:top_k]
     
     def get_autocomplete_suggestions(self, prefix: str, max_suggestions: int = 10) -> List[str]:
         """Return mock autocomplete suggestions."""
@@ -1370,6 +1382,169 @@ class TestServerFacetsNoSupport(ServerTestCase):
         self.assertEqual(status, 200)
         self.assertIn('Test 1', body)
         self.assertNotIn('<div class="facet-filters">', body)
+
+
+# ============================================================================
+# Issue #152: Synonym Toggle Tests
+# ============================================================================
+
+class TestRenderPageSynonymToggle(unittest.TestCase):
+    """Tests for synonym toggle rendering."""
+    
+    def test_renders_toggle_when_enabled(self):
+        """Should render synonym checkbox when show_synonym_toggle=True."""
+        html = render_page(
+            query='test',
+            results=[],
+            show_synonym_toggle=True
+        )
+        
+        self.assertIn('Expand synonyms', html)
+        self.assertIn('type="checkbox"', html)
+        self.assertIn('name="synonyms"', html)
+    
+    def test_no_toggle_when_disabled(self):
+        """Should not render synonym checkbox when show_synonym_toggle=False."""
+        html = render_page(
+            query='test',
+            results=[],
+            show_synonym_toggle=False
+        )
+        
+        self.assertNotIn('Expand synonyms', html)
+    
+    def test_checkbox_checked_when_active(self):
+        """Checkbox should be checked when synonyms_active=True."""
+        html = render_page(
+            query='test',
+            results=[],
+            show_synonym_toggle=True,
+            synonyms_active=True
+        )
+        
+        self.assertIn('checked', html)
+    
+    def test_checkbox_unchecked_when_inactive(self):
+        """Checkbox should not be checked when synonyms_active=False."""
+        html = render_page(
+            query='test',
+            results=[],
+            show_synonym_toggle=True,
+            synonyms_active=False
+        )
+        
+        # Count that 'checked' doesn't appear in checkbox element
+        checkbox_section = html.split('name="synonyms"')[1].split('>')[0]
+        self.assertNotIn('checked', checkbox_section)
+
+
+class TestServerSynonymToggle(ServerTestCase):
+    """Tests for synonym toggle in server responses."""
+    
+    @classmethod
+    def setUpClass(cls):
+        """Start test server with enhanced engine."""
+        normal_results = [
+            {'url': 'http://normal', 'title': 'Normal Result', 'score': 1.0}
+        ]
+        synonym_results = [
+            {'url': 'http://normal', 'title': 'Normal Result', 'score': 1.0},
+            {'url': 'http://synonym', 'title': 'Synonym Result', 'score': 0.9}
+        ]
+        cls.engine = MockEnhancedSearchEngine(
+            results=normal_results,
+            synonym_results=synonym_results
+        )
+        cls.start_server(engine=cls.engine, enable_synonyms=True)
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Stop test server."""
+        cls.stop_server()
+    
+    def test_shows_synonym_toggle(self):
+        """Should show synonym toggle checkbox."""
+        status, headers, body = self.make_request('/?q=test')
+        
+        self.assertEqual(status, 200)
+        self.assertIn('Expand synonyms', body)
+        self.assertIn('type="checkbox"', body)
+    
+    def test_synonyms_not_expanded_by_default(self):
+        """Synonyms should not be expanded without parameter."""
+        status, headers, body = self.make_request('/?q=test')
+        
+        self.assertEqual(status, 200)
+        self.assertEqual(self.engine._last_expand_synonyms, False)
+    
+    def test_synonyms_expanded_with_parameter(self):
+        """Synonyms should be expanded with ?synonyms=1."""
+        status, headers, body = self.make_request('/?q=test&synonyms=1')
+        
+        self.assertEqual(status, 200)
+        self.assertEqual(self.engine._last_expand_synonyms, True)
+    
+    def test_checkbox_preserves_state(self):
+        """Checkbox should be checked when synonyms=1."""
+        status, headers, body = self.make_request('/?q=test&synonyms=1')
+        
+        self.assertEqual(status, 200)
+        self.assertIn('checked', body)
+
+
+class TestServerSynonymToggleDisabled(ServerTestCase):
+    """Tests for server when synonym toggle is disabled."""
+    
+    @classmethod
+    def setUpClass(cls):
+        """Start test server with synonyms disabled."""
+        cls.engine = MockEnhancedSearchEngine(
+            results=[{'url': 'http://test', 'title': 'Test', 'score': 1.0}]
+        )
+        cls.start_server(engine=cls.engine, enable_synonyms=False)
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Stop test server."""
+        cls.stop_server()
+    
+    def test_no_toggle_when_disabled(self):
+        """Should not show synonym toggle when enable_synonyms=False."""
+        status, headers, body = self.make_request('/?q=test')
+        
+        self.assertEqual(status, 200)
+        self.assertNotIn('Expand synonyms', body)
+    
+    def test_parameter_ignored_when_disabled(self):
+        """?synonyms=1 should be ignored when toggle is disabled."""
+        status, headers, body = self.make_request('/?q=test&synonyms=1')
+        
+        self.assertEqual(status, 200)
+        self.assertEqual(self.engine._last_expand_synonyms, False)
+
+
+class TestServerSynonymBasicEngine(ServerTestCase):
+    """Tests with basic engine (no synonym support in search method)."""
+    
+    @classmethod
+    def setUpClass(cls):
+        """Start test server with basic engine."""
+        cls.engine = MockSearchEngine(
+            results=[{'url': 'http://test', 'title': 'Test', 'score': 1.0}]
+        )
+        cls.start_server(engine=cls.engine, enable_synonyms=True)
+    
+    @classmethod
+    def tearDownClass(cls):
+        """Stop test server."""
+        cls.stop_server()
+    
+    def test_works_without_expand_synonyms_param(self):
+        """Server should work when engine search() lacks expand_synonyms."""
+        status, headers, body = self.make_request('/?q=test&synonyms=1')
+        
+        self.assertEqual(status, 200)
+        self.assertIn('Test', body)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes #152

## Summary
Adds a synonym expansion toggle checkbox to the web UI search form.

## Changes
- Added CSS styles for `.search-options` and `.synonym-toggle`
- Added `enable_synonyms` parameter to `run_server()` and `SearchHandler`
- Added `synonyms_active` and `show_synonym_toggle` parameters to `render_page()`
- Parse `?synonyms=1` query parameter to enable synonym expansion
- Pass `expand_synonyms` to engine's `search()` method if supported
- Checkbox state preserved across searches

## Acceptance Criteria
- [x] Synonym toggle checkbox in search form
- [x] `?synonyms=1` enables expansion
- [x] State preserved across searches
- [x] Works with existing synonym dictionary (when engine supports it)
- [x] Can be enabled/disabled via `enable_synonyms` parameter
- [x] Tests for synonym toggle (11 new tests)
- [x] No JavaScript required

## Testing
- 11 new test cases for synonym toggle functionality
- All 1003 tests pass