### PR TITLE
refactor: Remove synonym toggle checkbox from UI

### DIFF
--- a/doc_search/server.py
+++ b/doc_search/server.py
@@ -164,34 +164,6 @@ a:hover {
     transform: scale(0.98);
 }
 
-/* Search options (synonym toggle) */
-.search-options {
-    margin-top: 0.75rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.synonym-toggle {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    cursor: pointer;
-    color: var(--text-secondary);
-    font-size: 0.875rem;
-}
-
-.synonym-toggle input[type="checkbox"] {
-    width: 1rem;
-    height: 1rem;
-    accent-color: var(--accent);
-    cursor: pointer;
-}
-
-.synonym-toggle:hover {
-    color: var(--text-primary);
-}
-
 /* Results info */
 .results-info {
     display: flex;
@@ -575,28 +547,13 @@ def render_page(
     suggestion: Optional[str] = None,
     facets: Optional[Dict[str, Dict[str, int]]] = None,
     active_facet: Optional[str] = None,
-    total_unfiltered: int = 0,
-    synonyms_active: bool = False,
-    show_synonym_toggle: bool = False
+    total_unfiltered: int = 0
 ) -> str:
     """Render the full HTML page."""
     
     stats = stats or {}
     total_docs = stats.get('total_documents', 0)
     unique_terms = stats.get('unique_terms', 0)
-    
-    # Build synonym toggle HTML
-    synonym_toggle_html = ""
-    if show_synonym_toggle:
-        checked = 'checked' if synonyms_active else ''
-        synonym_toggle_html = f'''
-            <div class="search-options">
-                <label class="synonym-toggle">
-                    <input type="checkbox" name="synonyms" value="1" {checked}>
-                    <span>Expand synonyms</span>
-                </label>
-            </div>
-        '''
     
     # Build facet filter HTML
     facets_html = ""
@@ -766,7 +723,6 @@ def render_page(
                 >
                 <button type="submit" class="search-button">Search</button>
             </div>
-            {synonym_toggle_html}
         </form>
         
         {results_html}
@@ -858,12 +814,6 @@ class SearchHandler(BaseHTTPRequestHandler):
         # Get facet filter (category)
         category_filter = query_params.get('category', [''])[0].strip() if self.enable_facets else ''
         
-        # Get synonym toggle state (synonyms=1 enables expansion)
-        synonyms_active = False
-        if self.enable_synonyms:
-            synonyms_param = query_params.get('synonyms', [''])[0].strip()
-            synonyms_active = synonyms_param == '1'
-        
         per_page = self.per_page
         max_results = self.max_results
         
@@ -873,8 +823,8 @@ class SearchHandler(BaseHTTPRequestHandler):
         if query:
             # Perform search - fetch enough for pagination
             search_start = time.perf_counter()
-            # Pass expand_synonyms if engine supports it (EnhancedSearchEngine)
-            if synonyms_active and hasattr(self.engine, 'search'):
+            # Pass expand_synonyms if enabled and engine supports it
+            if self.enable_synonyms and hasattr(self.engine, 'search'):
                 import inspect
                 sig = inspect.signature(self.engine.search)
                 if 'expand_synonyms' in sig.parameters:
@@ -930,13 +880,11 @@ class SearchHandler(BaseHTTPRequestHandler):
                 suggestion=suggestion,
                 facets=facets,
                 active_facet=category_filter if category_filter else None,
-                total_unfiltered=total_unfiltered,
-                synonyms_active=synonyms_active,
-                show_synonym_toggle=self.enable_synonyms
+                total_unfiltered=total_unfiltered
             )
         else:
             # Welcome page
-            html_content = render_page(stats=stats, show_synonym_toggle=self.enable_synonyms)
+            html_content = render_page(stats=stats)
         
         self.send_html(html_content)
     

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1388,62 +1388,16 @@ class TestServerFacetsNoSupport(ServerTestCase):
 # Issue #152: Synonym Toggle Tests
 # ============================================================================
 
-class TestRenderPageSynonymToggle(unittest.TestCase):
-    """Tests for synonym toggle rendering."""
-    
-    def test_renders_toggle_when_enabled(self):
-        """Should render synonym checkbox when show_synonym_toggle=True."""
-        html = render_page(
-            query='test',
-            results=[],
-            show_synonym_toggle=True
-        )
-        
-        self.assertIn('Expand synonyms', html)
-        self.assertIn('type="checkbox"', html)
-        self.assertIn('name="synonyms"', html)
-    
-    def test_no_toggle_when_disabled(self):
-        """Should not render synonym checkbox when show_synonym_toggle=False."""
-        html = render_page(
-            query='test',
-            results=[],
-            show_synonym_toggle=False
-        )
-        
-        self.assertNotIn('Expand synonyms', html)
-    
-    def test_checkbox_checked_when_active(self):
-        """Checkbox should be checked when synonyms_active=True."""
-        html = render_page(
-            query='test',
-            results=[],
-            show_synonym_toggle=True,
-            synonyms_active=True
-        )
-        
-        self.assertIn('checked', html)
-    
-    def test_checkbox_unchecked_when_inactive(self):
-        """Checkbox should not be checked when synonyms_active=False."""
-        html = render_page(
-            query='test',
-            results=[],
-            show_synonym_toggle=True,
-            synonyms_active=False
-        )
-        
-        # Count that 'checked' doesn't appear in checkbox element
-        checkbox_section = html.split('name="synonyms"')[1].split('>')[0]
-        self.assertNotIn('checked', checkbox_section)
+# ============================================================================
+# Issue #152: Synonym Expansion Tests (CLI flag, no UI toggle)
+# ============================================================================
 
-
-class TestServerSynonymToggle(ServerTestCase):
-    """Tests for synonym toggle in server responses."""
+class TestServerSynonymsEnabled(ServerTestCase):
+    """Tests for server with synonyms enabled via CLI flag."""
     
     @classmethod
     def setUpClass(cls):
-        """Start test server with enhanced engine."""
+        """Start test server with synonyms enabled."""
         normal_results = [
             {'url': 'http://normal', 'title': 'Normal Result', 'score': 1.0}
         ]
@@ -1462,38 +1416,24 @@ class TestServerSynonymToggle(ServerTestCase):
         """Stop test server."""
         cls.stop_server()
     
-    def test_shows_synonym_toggle(self):
-        """Should show synonym toggle checkbox."""
+    def test_no_checkbox_in_ui(self):
+        """Should NOT show synonym checkbox in UI (CLI flag only)."""
         status, headers, body = self.make_request('/?q=test')
         
         self.assertEqual(status, 200)
-        self.assertIn('Expand synonyms', body)
-        self.assertIn('type="checkbox"', body)
+        self.assertNotIn('Expand synonyms', body)
+        self.assertNotIn('name="synonyms"', body)
     
-    def test_synonyms_not_expanded_by_default(self):
-        """Synonyms should not be expanded without parameter."""
+    def test_synonyms_always_expanded_when_enabled(self):
+        """Synonyms should always be expanded when enable_synonyms=True."""
         status, headers, body = self.make_request('/?q=test')
-        
-        self.assertEqual(status, 200)
-        self.assertEqual(self.engine._last_expand_synonyms, False)
-    
-    def test_synonyms_expanded_with_parameter(self):
-        """Synonyms should be expanded with ?synonyms=1."""
-        status, headers, body = self.make_request('/?q=test&synonyms=1')
         
         self.assertEqual(status, 200)
         self.assertEqual(self.engine._last_expand_synonyms, True)
-    
-    def test_checkbox_preserves_state(self):
-        """Checkbox should be checked when synonyms=1."""
-        status, headers, body = self.make_request('/?q=test&synonyms=1')
-        
-        self.assertEqual(status, 200)
-        self.assertIn('checked', body)
 
 
-class TestServerSynonymToggleDisabled(ServerTestCase):
-    """Tests for server when synonym toggle is disabled."""
+class TestServerSynonymsDisabled(ServerTestCase):
+    """Tests for server with synonyms disabled."""
     
     @classmethod
     def setUpClass(cls):
@@ -1508,22 +1448,15 @@ class TestServerSynonymToggleDisabled(ServerTestCase):
         """Stop test server."""
         cls.stop_server()
     
-    def test_no_toggle_when_disabled(self):
-        """Should not show synonym toggle when enable_synonyms=False."""
+    def test_synonyms_not_expanded_when_disabled(self):
+        """Synonyms should NOT be expanded when enable_synonyms=False."""
         status, headers, body = self.make_request('/?q=test')
-        
-        self.assertEqual(status, 200)
-        self.assertNotIn('Expand synonyms', body)
-    
-    def test_parameter_ignored_when_disabled(self):
-        """?synonyms=1 should be ignored when toggle is disabled."""
-        status, headers, body = self.make_request('/?q=test&synonyms=1')
         
         self.assertEqual(status, 200)
         self.assertEqual(self.engine._last_expand_synonyms, False)
 
 
-class TestServerSynonymBasicEngine(ServerTestCase):
+class TestServerSynonymsBasicEngine(ServerTestCase):
     """Tests with basic engine (no synonym support in search method)."""
     
     @classmethod
@@ -1539,9 +1472,9 @@ class TestServerSynonymBasicEngine(ServerTestCase):
         """Stop test server."""
         cls.stop_server()
     
-    def test_works_without_expand_synonyms_param(self):
+    def test_works_without_expand_synonyms_support(self):
         """Server should work when engine search() lacks expand_synonyms."""
-        status, headers, body = self.make_request('/?q=test&synonyms=1')
+        status, headers, body = self.make_request('/?q=test')
         
         self.assertEqual(status, 200)
         self.assertIn('Test', body)


### PR DESCRIPTION
## Summary
Removes the 'Expand synonyms' checkbox from the web UI per user request.

## Changes
- Removed checkbox CSS and HTML from UI
- Synonyms now controlled **only** via `enable_synonyms` CLI flag
- When enabled, synonyms are always expanded (no toggle)
- Simplified `render_page()` by removing unused parameters

## Behavior
- `--enable-synonyms` flag → synonyms always expanded
- No flag (default) → synonyms not expanded
- No user-facing toggle in UI

## Tests
- 996 tests pass
- Removed 7 UI checkbox tests
- Kept 4 CLI-flag behavior tests