### PR TITLE
fix: thread safety + --ignore-robots flag

### DIFF
--- a/doc_search/cli/commands.py
+++ b/doc_search/cli/commands.py
@@ -147,6 +147,7 @@ def cmd_crawl(args):
         auth=auth,
         auth_token=auth_token,
         same_path=getattr(args, 'same_path', False),
+        ignore_robots=getattr(args, 'ignore_robots', False),
         verbose=not args.quiet,
         workers=args.workers,
         extract_docs=args.extract_docs,

--- a/doc_search/cli/parsers.py
+++ b/doc_search/cli/parsers.py
@@ -77,6 +77,8 @@ def _add_crawl_parser(subparsers):
                              help='Maximum link depth from starting URL')
     crawl_parser.add_argument('--same-path', action='store_true',
                              help='Only crawl URLs under the starting path (default: crawl entire domain)')
+    crawl_parser.add_argument('--ignore-robots', action='store_true',
+                             help='Ignore robots.txt rules (use responsibly)')
     crawl_parser.add_argument('--fresh', '-f', action='store_true',
                              help='Start fresh crawl (ignore saved state)')
     crawl_parser.add_argument('--incremental', '-i', action='store_true',

--- a/doc_search/crawl_state.py
+++ b/doc_search/crawl_state.py
@@ -69,15 +69,17 @@ class CrawlState:
     def save(self):
         """Save state to disk (thread-safe)."""
         with self._lock:
+            # Create deep copies of all mutable state to avoid race conditions
+            # during json.dump() which happens outside the lock
             state = {
                 'visited': list(self.visited),
                 'pending': list(self.pending),
-                'failed': self.failed,
+                'failed': dict(self.failed),  # Copy dict
                 'errors': [e.to_dict() for e in self.errors],
-                'stats': self.stats
+                'stats': dict(self.stats)  # Copy dict to avoid modification during dump
             }
         
-        # Write atomically
+        # Write atomically (outside lock to avoid blocking other threads)
         tmp_file = self.state_file.with_suffix('.tmp')
         with open(tmp_file, 'w') as f:
             json.dump(state, f)

--- a/doc_search/crawler/_crawler.py
+++ b/doc_search/crawler/_crawler.py
@@ -61,6 +61,7 @@ class Crawler:
         auth_token: Optional[str] = None,
         stay_on_domain: bool = True,
         same_path: bool = False,
+        ignore_robots: bool = False,
         url_filter: Optional[Callable[[str], bool]] = None,
         verbose: bool = True,
         workers: int = 1,
@@ -83,6 +84,7 @@ class Crawler:
             auth_token: Pre-encoded Base64 auth token.
             stay_on_domain: If True, only crawl URLs on same domain.
             same_path: If True, only crawl URLs under the starting path.
+            ignore_robots: If True, ignore robots.txt rules (use responsibly).
             url_filter: Optional custom filter function for URLs.
             verbose: If True, print progress messages.
             workers: Number of parallel workers (default 1).
@@ -102,6 +104,7 @@ class Crawler:
         self.workers = max(1, workers)
         self.extract_docs = extract_docs
         self.incremental = incremental
+        self.ignore_robots = ignore_robots
         
         # Initialize PDF extractor if document extraction is enabled
         self._pdf_extractor = None
@@ -121,8 +124,8 @@ class Crawler:
         # Initialize state
         self.state = CrawlState(self.data_dir / 'crawl_state.json')
         
-        # Initialize robots checker
-        self.robots = RobotsChecker(base_url, self.USER_AGENT)
+        # Initialize robots checker (None if ignoring robots.txt)
+        self.robots = None if ignore_robots else RobotsChecker(base_url, self.USER_AGENT)
         
         # Initialize rate limiter
         self.rate_limiter = RateLimiter(delay)
@@ -398,17 +401,20 @@ class Crawler:
         Returns:
             Dict with crawl statistics.
         """
-        # Load robots.txt
-        self._log("Loading robots.txt...")
-        self.robots.load()
-        
-        # Get crawl delay from robots.txt
-        robots_delay = self.robots.get_crawl_delay(self.delay)
-        if robots_delay > self.delay:
-            self._log(f"Respecting robots.txt crawl-delay: {robots_delay}s")
-            self.delay = robots_delay
-            self.rate_limiter = RateLimiter(self.delay)
-            self._fetcher.rate_limiter = self.rate_limiter
+        # Load robots.txt (unless ignored)
+        if self.robots:
+            self._log("Loading robots.txt...")
+            self.robots.load()
+            
+            # Get crawl delay from robots.txt
+            robots_delay = self.robots.get_crawl_delay(self.delay)
+            if robots_delay > self.delay:
+                self._log(f"Respecting robots.txt crawl-delay: {robots_delay}s")
+                self.delay = robots_delay
+                self.rate_limiter = RateLimiter(self.delay)
+                self._fetcher.rate_limiter = self.rate_limiter
+        else:
+            self._log("Ignoring robots.txt (--ignore-robots)")
         
         # Load or initialize state
         if self.incremental:


### PR DESCRIPTION
## Changes

### 1. Thread Safety Fix in `crawl_state.py`
Fixed a race condition in `CrawlState.save()` that could cause:
```
RuntimeError: dictionary changed size during iteration
```

**The bug:** `self.stats` and `self.failed` were assigned by reference in the `state` dict. When the lock was released, other threads could modify these dicts while `json.dump()` was iterating over them.

**The fix:** Create copies of the dicts inside the lock:
```python
'failed': dict(self.failed),  # Copy dict
'stats': dict(self.stats)     # Copy dict
```

### 2. New `--ignore-robots` Flag
Adds ability to ignore robots.txt rules when crawling:
```bash
doc-search crawl https://example.com --ignore-robots
```

- Works for both single-threaded and multi-threaded crawling
- Skips robots.txt loading entirely
- Use responsibly - robots.txt exists for good reasons

### 3. Investigation: No Duplicate RobotsChecker
Investigated potential duplicate initialization of RobotsChecker - confirmed there is no duplication. RobotsChecker is created once in `Crawler.__init__` and passed to `UrlFilter`.

## Testing
All 1031 tests pass.